### PR TITLE
修复物品栏取消选择后回到最顶端的bug

### DIFF
--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -2141,7 +2141,7 @@ void CIsoView::OnRButtonUp(UINT nFlags, CPoint point)
 			AD.reset();
 
 			CMyViewFrame& frame = *((CMyViewFrame*)owner);
-			frame.m_objectview->GetTreeCtrl().Select(frame.m_objectview->GetTreeCtrl().GetRootItem(), TVGN_CARET);
+			frame.m_objectview->GetTreeCtrl().Select(NULL, TVGN_CARET);
 		}
 		return;
 	}


### PR DESCRIPTION
修复前
![treeview2](https://github.com/user-attachments/assets/7eee05a1-6ab6-44a1-86ee-b813cf0cbf3b)

修复后
![treeview3](https://github.com/user-attachments/assets/973865f9-e6c9-4ff6-a58b-e65dc4432cfe)

