### PR TITLE
让长按放置的覆盖物可以一次性撤销重做

### DIFF
--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -1957,8 +1957,6 @@ void CIsoView::OnMouseMove(UINT nFlags, CPoint point)
 	} else if ((nFlags & MK_LBUTTON) == MK_LBUTTON && (AD.mode == ACTIONMODE_PLACE || AD.mode == ACTIONMODE_RANDOMTERRAIN)) {
 		// ADD OBJECTS
 
-		if (AD.mode == ACTIONMODE_PLACE && AD.type == 6) Map->TakeSnapshot();
-
 		if (AD.mode == ACTIONMODE_PLACE && AD.type == 6 && AD.data == 5) // bridges		
 		{
 
@@ -2021,14 +2019,6 @@ void CIsoView::OnMouseMove(UINT nFlags, CPoint point)
 			PlaceCurrentObjectAt(x, y);
 			RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
 		}
-
-
-		if (AD.mode == ACTIONMODE_PLACE && AD.type == 6) {
-			Map->TakeSnapshot();
-			Map->Undo();
-		}
-
-
 	}
 
 	UpdateStatusBar(x, y);
@@ -2789,6 +2779,10 @@ void CIsoView::OnLButtonDown(UINT nFlags, CPoint point)
 		m_id = Map->GetCelltagAt(m_mapx + m_mapy * Map->GetIsoSize());
 		m_type = 5;
 	} else if ((AD.mode < 3 || AD.mode>4) || (AD.mode == 3 && AD.type == 0) || (AD.mode >= 3 && AD.mode <= 4 && AD.type == 1)) {
+		if (AD.type == 6)
+		{
+			Map->TakeSnapshot();
+		}
 		OnMouseMove(nFlags, point);
 	} else if (AD.mode == 3) {
 		if (AD.type == 2) {
@@ -3126,6 +3120,8 @@ void CIsoView::OnLButtonUp(UINT nFlags, CPoint point)
 		m_moved = FALSE;
 		if (AD.type == 6) // Overlay
 		{
+			Map->TakeSnapshot();
+			Map->Undo();
 			if (AD.data == 5) // birdges
 			{
 				if (x == m_mapx && y == m_mapy) return;

--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -3120,8 +3120,6 @@ void CIsoView::OnLButtonUp(UINT nFlags, CPoint point)
 		m_moved = FALSE;
 		if (AD.type == 6) // Overlay
 		{
-			Map->TakeSnapshot();
-			Map->Undo();
 			if (AD.data == 5) // birdges
 			{
 				if (x == m_mapx && y == m_mapy) return;
@@ -3318,6 +3316,8 @@ void CIsoView::OnLButtonUp(UINT nFlags, CPoint point)
 				//UpdateMap();
 				RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
 			}
+			Map->TakeSnapshot();
+			Map->Undo();
 		}
 	}
 


### PR DESCRIPTION
![overlay_rn](https://github.com/user-attachments/assets/f5fc309b-2e32-4d95-854f-43395bd9de0e)

之前每次摆放覆盖图的函数都会记录一次撤销操作，如果你长按摆放了很多覆盖图，撤销起来会非常麻烦，并且会直接填满本就有限的撤销记录。现在长按撤销是一次性的，与使地形变得平坦工具一致