### PR TITLE
修复#120导致的当前所属方改变bug

### DIFF
--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -2138,6 +2138,11 @@ void CIsoView::OnRButtonUp(UINT nFlags, CPoint point)
 		if (!ignoreClick) {
 			AD.reset();
 		}
+
+		CTreeCtrl& treeCtrl = ((CMyViewFrame*)owner)->m_objectview->GetTreeCtrl();
+		HTREEITEM hParentItem = treeCtrl.GetParentItem(treeCtrl.GetSelectedItem());
+		treeCtrl.Select(hParentItem, TVGN_CARET);
+
 		return;
 	}
 

--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -2137,8 +2137,6 @@ void CIsoView::OnRButtonUp(UINT nFlags, CPoint point)
 
 		if (!ignoreClick) {
 			AD.reset();
-
-			CMyViewFrame& frame = *((CMyViewFrame*)owner);
 		}
 		return;
 	}

--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -2139,7 +2139,6 @@ void CIsoView::OnRButtonUp(UINT nFlags, CPoint point)
 			AD.reset();
 
 			CMyViewFrame& frame = *((CMyViewFrame*)owner);
-			frame.m_objectview->GetTreeCtrl().Select(NULL, TVGN_CARET);
 		}
 		return;
 	}


### PR DESCRIPTION
#120 选择null会选择当前可视区域最上方的元素，假如这个元素恰好是所属方（如下图），就会导致当前所属方发生改变。
所以这里的方法是直接不改变选择项，缺点是如果取消选择之后再次选择同一个项，不会触发选择改变事件，这时候只能手动选择一个别的项再选回来。不过我觉得这样仍然比直接会到根节点要好

<img width="179" alt="Snipaste_2024-12-25_00-24-45" src="https://github.com/user-attachments/assets/7a934792-2948-4c76-8f57-e265f19cc461" />
