### PR TITLE
Fix: Map resize

### DIFF
--- a/MissionEditor/MapD.cpp
+++ b/MissionEditor/MapD.cpp
@@ -151,7 +151,9 @@ void CMapD::OnChange()
 	*/
 
 	CChangeSizeDlg dlg;
-	if (dlg.DoModal() == IDCANCEL) return;
+	if (dlg.DoModal() == IDCANCEL) {
+		return;
+	}
 
 	if (dlg.m_Width < 16 || dlg.m_Width>400 || dlg.m_Height < 16 || dlg.m_Height>400 || (dlg.m_Width + dlg.m_Height) > 512) {
 		MessageBox("Width and Height must both be between 16 and 400 and both added must be less than 512.", "Error");

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -1856,18 +1856,17 @@ void CMapData::UpdateNodes(BOOL bSave)
 			CString nodeName;
 			GetNodeID(nodeName, idx);
 			auto const& nodeVal = sec.GetString(nodeName);
-			CString type, sx, sy;
-			type = GetParam(nodeVal, 0);
-			sy = GetParam(nodeVal, 1);
-			sx = GetParam(nodeVal, 2);
+			const auto type = GetParam(nodeVal, 0);
+			const auto sy = GetParam(nodeVal, 1);
+			const auto sx = GetParam(nodeVal, 2);
 
-			int x = atoi(sx);
-			int y = atoi(sy);
-			int bid = buildingid[type];
+			const int x = atoi(sx);
+			const int y = atoi(sy);
+			const int bid = buildingid.at(type);
 			for (auto d = 0; d < buildinginfo[bid].h; d++) {
 				for (auto f = 0; f < buildinginfo[bid].w; f++) {
 					int pos = x + d + (y + f) * GetIsoSize();
-					fielddata[pos].node.type = buildingid[type];
+					fielddata[pos].node.type = bid;
 					fielddata[pos].node.house = id;
 					fielddata[pos].node.index = idx;
 				}
@@ -6437,7 +6436,9 @@ BOOL CMapData::AddSmudge(SMUDGE* lpSmudge)
 	td = *lpSmudge;
 	int pos = td.x + td.y * GetIsoSize();
 
-	if (smudgeid.find(td.type) == smudgeid.end()) return FALSE;
+	if (smudgeid.find(td.type) == smudgeid.end()) {
+		return FALSE;
+	}
 
 	BOOL bFound = FALSE;
 

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -5866,6 +5866,7 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	int ct_count = GetCelltagCount();
 	DWORD* ct_pos = new(DWORD[GetCelltagCount()]);
 	auto baseNodes = CollectAllBaseNodes();
+	auto const smudgeSize = m_mapfile["Smudge"].Size();
 
 	// Now copy the objects into above arrays and delete them from map
 	for (int i = 0; i < inf_count; i++) {
@@ -6060,6 +6061,8 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 			fdd.overlaydata = fdo.overlaydata;
 			fdd.wGround = fdo.wGround;
 			fdd.node = fdo.node;
+			fdd.smudge = fdo.smudge;
+			fdd.smudgetype = fdo.smudgetype;
 		}
 	}
 
@@ -6072,6 +6075,7 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 		+ GetWaypointCount() 
 		+ GetCelltagCount()
 		+ baseNodes.size()
+		+ smudgeSize
 		;
 	int progress = 0;
 	CProgressDlg* dlg = new(CProgressDlg)("Updating objects, please wait");
@@ -6289,7 +6293,26 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 			dlg->UpdateWindow();
 		}
 		progress += progressCounter;
+	}
 
+	if (!m_smudges.empty()) {
+		int progressCounter = 0;
+		for (auto& smudge : m_smudges) {
+			const int x = smudge.x + x_move;
+			const int y = smudge.y + y_move;
+
+			if (!isInMap(x, y)) {
+				smudge.deleted = true;
+				continue;
+			}
+			smudge.x = x;
+			smudge.y = y;
+
+			dlg->SetPosition(progressCounter++ + progress);
+			dlg->UpdateWindow();
+		}
+		UpdateSmudges(TRUE);
+		progress += progressCounter;
 	}
 
 	// data transfer complete!
@@ -6557,7 +6580,6 @@ void CMapData::DeleteSmudge(DWORD dwIndex)
 
 void CMapData::UpdateSmudges(BOOL bSave, int num)
 {
-	vector<SMUDGE>& smudges = m_smudges;
 
 	if (bSave == FALSE) {
 		auto const& sec = m_mapfile.GetSection("Smudge");
@@ -6566,8 +6588,8 @@ void CMapData::UpdateSmudges(BOOL bSave, int num)
 		}
 
 		if (num < 0) {
-			smudges.clear();
-			smudges.reserve(100);
+			m_smudges.clear();
+			m_smudges.reserve(100);
 
 			for (auto i = 0; i < GetIsoSize() * GetIsoSize(); i++) {
 				fielddata[i].smudge = -1;
@@ -6593,7 +6615,7 @@ void CMapData::UpdateSmudges(BOOL bSave, int num)
 				td.x = x;
 				td.y = y;
 
-				smudges.push_back(td);
+				m_smudges.push_back(td);
 
 				int pos = x + y * GetIsoSize();
 				fielddata[pos].smudge = i;
@@ -6607,15 +6629,15 @@ void CMapData::UpdateSmudges(BOOL bSave, int num)
 	}
 
 
-
+	// SAVE == TRUE
 	//if(num<0)
 	{
 		//if(m_mapfile.sections.find("Smudge")!=m_mapfile.sections.end()) MessageBox(0,"Reupdate!","",0);
 		m_mapfile.DeleteSection("Smudge");
 		int i;
 
-		for (i = 0; i < smudges.size(); i++) {
-			auto const& td = smudges[i];
+		for (i = 0; i < m_smudges.size(); i++) {
+			auto const& td = m_smudges[i];
 			if (!td.deleted) {
 				char numBuffer[50];
 				CString val = td.type;

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -5940,8 +5940,8 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	}
 
 	auto const old_fd = std::exchange(fielddata, {});
-	const int ow = GetWidth();
-	const int oh = GetHeight();
+	const int oldWidth = GetWidth();
+	const int oldHeight = GetHeight();
 	const int oldIsoSize = GetIsoSize();
 	auto const old_fds = fielddata.size();
 
@@ -5969,26 +5969,26 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	dwSnapShotCount = 0;
 	m_cursnapshot = -1;
 
-
-	char c[50];
 	CString mapsize;
-	itoa(dwNewWidth, c, 10);
-	mapsize = "0,0,";
-	mapsize += c;
-	itoa(dwNewHeight, c, 10);
-	mapsize += ",";
-	mapsize += c;
+	mapsize.Format("0,0,%d,%d", dwNewWidth, dwNewHeight);
 
 	m_mapfile.SetString("Map", "Size", mapsize);
 
 	{
-		auto const oldLocalSize = m_mapfile.GetString("Map", "LocalSize");
-		auto const newLeft = atoi(GetParam(oldLocalSize, 0)) + left;
-		auto const newTop = atoi(GetParam(oldLocalSize, 1)) + top;
-		auto const oldWidthStr = GetParam(oldLocalSize, 2);
-		auto const oldHeightStr = GetParam(oldLocalSize, 3);
+		auto const oldVisualRect = m_mapfile.GetString("Map", "LocalSize");
+		auto const newVisualLeft = std::max(1, atoi(GetParam(oldVisualRect, 0)) + left);
+		auto const newVisualTop = std::max(1, atoi(GetParam(oldVisualRect, 1)) + top);
+		auto newVisualWidth = std::min<int>(dwNewWidth, atoi(GetParam(oldVisualRect, 2)));
+		auto newVisualHeight = std::min<int>(dwNewHeight, atoi(GetParam(oldVisualRect, 3)));
 
-		mapsize.Format("%d,%d,%s,%s", newLeft, newTop, oldWidthStr, oldHeightStr);
+		if (newVisualWidth + newVisualLeft > dwNewWidth) {
+			newVisualWidth = dwNewWidth - newVisualLeft - 1;
+		}
+		if (newVisualHeight + newVisualTop > dwNewHeight) {
+			newVisualHeight = dwNewHeight - newVisualTop - 1;
+		}
+
+		mapsize.Format("%d,%d,%d,%d", newVisualLeft, newVisualTop, newVisualWidth, newVisualHeight);
 
 		m_mapfile.SetString("Map", "LocalSize", mapsize);
 	}
@@ -6015,7 +6015,7 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	int x_move = 0;
 	int y_move = 0;
 
-	x_move += (dwNewWidth - ow);
+	x_move += (dwNewWidth - oldWidth);
 
 
 	// x_move and y_move now take care of the map sizing. This means,

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -5940,14 +5940,13 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	}
 
 	auto const old_fd = std::exchange(fielddata, {});
-	int ow = GetWidth();
-	int oh = GetHeight();
-	int oldIsoSize = GetIsoSize();
+	const int ow = GetWidth();
+	const int oh = GetHeight();
+	const int oldIsoSize = GetIsoSize();
 	auto const old_fds = fielddata.size();
 
-	int left = iLeft;
-	int top = iTop;
-
+	const int left = iLeft;
+	const int top = iTop;
 
 	// hmm, erase any snapshots... we probably can remove this and do coordinate conversion instead
 	// but for now we just delete them...
@@ -5982,15 +5981,17 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 	m_mapfile.SetString("Map", "Size", mapsize);
 
-	itoa(dwNewWidth - 4, c, 10);
-	mapsize = "2,4,";
-	mapsize += c;
-	itoa(dwNewHeight - 6, c, 10);
-	mapsize += ",";
-	mapsize += c;
+	{
+		auto const oldLocalSize = m_mapfile.GetString("Map", "LocalSize");
+		auto const newLeft = atoi(GetParam(oldLocalSize, 0)) + left;
+		auto const newTop = atoi(GetParam(oldLocalSize, 1)) + top;
+		auto const oldWidthStr = GetParam(oldLocalSize, 2);
+		auto const oldHeightStr = GetParam(oldLocalSize, 3);
 
-	m_mapfile.SetString("Map", "LocalSize", mapsize);
+		mapsize.Format("%d,%d,%s,%s", newLeft, newTop, oldWidthStr, oldHeightStr);
 
+		m_mapfile.SetString("Map", "LocalSize", mapsize);
+	}
 
 	CalcMapRect();
 	ClearOverlay();
@@ -6005,9 +6006,10 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 	errstream << "ResizeMap() frees m_mfd\n";
 	errstream.flush();
-	if (m_mfd != NULL) delete[] m_mfd;
+	if (m_mfd != NULL) {
+		delete[] m_mfd;
+	}
 	m_mfd = NULL;
-
 
 	// x_move and y_move specify the movement for each field, related to the old position
 	int x_move = 0;

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -5945,8 +5945,8 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	const int oldIsoSize = GetIsoSize();
 	auto const old_fds = fielddata.size();
 
-	const int left = iLeft;
-	const int top = iTop;
+	const int leftExpansion = iLeft;
+	const int topExpansion = iTop;
 
 	// hmm, erase any snapshots... we probably can remove this and do coordinate conversion instead
 	// but for now we just delete them...
@@ -5976,8 +5976,8 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 	{
 		auto const oldVisualRect = m_mapfile.GetString("Map", "LocalSize");
-		auto const newVisualLeft = std::max(1, atoi(GetParam(oldVisualRect, 0)) + left);
-		auto const newVisualTop = std::max(1, atoi(GetParam(oldVisualRect, 1)) + top);
+		auto const newVisualLeft = std::max(1, atoi(GetParam(oldVisualRect, 0)) + leftExpansion);
+		auto const newVisualTop = std::max(1, atoi(GetParam(oldVisualRect, 1)) + topExpansion);
 		auto newVisualWidth = std::min<int>(dwNewWidth, atoi(GetParam(oldVisualRect, 2)));
 		auto newVisualHeight = std::min<int>(dwNewHeight, atoi(GetParam(oldVisualRect, 3)));
 
@@ -6023,11 +6023,11 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	// but we want to consider left and right, as the user selected it.
 	// so, do some coordinate conversion:
 
-	x_move += top;
-	y_move += top;
+	x_move += topExpansion;
+	y_move += topExpansion;
 
-	x_move += -left;
-	y_move += left;
+	x_move += -leftExpansion;
+	y_move += leftExpansion;
 
 	//char c[50];
 	/*char d[50];

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -2211,7 +2211,7 @@ void CMapData::GetNthStdStructureData(DWORD dwIndex, STDOBJECTDATA* lpStdStructu
 	ParseBasicTechnoData(data, *lpStdStructure);
 }
 
-BOOL CMapData::AddNode(NODE* lpNode, WORD dwPos)
+BOOL CMapData::AddNode(const NODE* lpNode, WORD dwPos, bool reloadAll)
 {
 	NODE node;
 	if (lpNode != NULL) {
@@ -2243,7 +2243,9 @@ BOOL CMapData::AddNode(NODE* lpNode, WORD dwPos)
 
 	m_mapfile.SetString(node.house, p, std::move(nodeRecord));
 
-	UpdateNodes(FALSE);
+	if (reloadAll) {
+		UpdateNodes(FALSE);
+	}
 
 	return TRUE;
 }
@@ -3025,6 +3027,29 @@ void CMapData::GetStdUnitData(DWORD dwIndex, STDOBJECTDATA* lpStdUnit) const
 DWORD CMapData::GetInfantryCount() const
 {
 	return m_infantry.size();//m_mapfile.sections["Infantry"].values.size();
+}
+
+std::vector<NODE> CMapData::CollectAllBaseNodes() const
+{
+	size_t total = 0;
+	for (auto const& [seq, id] : m_mapfile[MAPHOUSES]) {
+		total += m_mapfile.GetInteger(id, "NodeCount");
+	}
+	std::vector<NODE> ret;
+	ret.reserve(total);
+
+	for (auto const& [seq, id] : m_mapfile[MAPHOUSES]) {
+		auto const& sec = m_mapfile.GetSection(id);
+		const int nodeCount = sec.GetInteger("NodeCount");
+		for (auto idx = 0; idx < nodeCount; idx++) {
+			auto const& nodeVal = sec.GetString(GetNodeID(idx));
+			auto const type = GetParam(nodeVal, 0);
+			const CString y = GetParam(nodeVal, 1);
+			const CString x = GetParam(nodeVal, 2);
+			ret.push_back(NODE{ id, type, x, y });
+		}
+	}
+	return ret;
 }
 
 DWORD CMapData::GetUnitCount() const
@@ -5840,6 +5865,7 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	CString* ct_tag = new(CString[GetCelltagCount()]);
 	int ct_count = GetCelltagCount();
 	DWORD* ct_pos = new(DWORD[GetCelltagCount()]);
+	auto baseNodes = CollectAllBaseNodes();
 
 	// Now copy the objects into above arrays and delete them from map
 	for (int i = 0; i < inf_count; i++) {
@@ -5915,7 +5941,7 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	auto const old_fd = std::exchange(fielddata, {});
 	int ow = GetWidth();
 	int oh = GetHeight();
-	int os = GetIsoSize();
+	int oldIsoSize = GetIsoSize();
 	auto const old_fds = fielddata.size();
 
 	int left = iLeft;
@@ -6010,18 +6036,17 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	};
 
 	// copy tiles now
-	for (int i = 0; i < os; i++) {
-		for (int e = 0; e < os; e++) {
-			int x, y;
-			x = i + x_move;
-			y = e + y_move;
+	for (int i = 0; i < oldIsoSize; i++) {
+		for (int e = 0; e < oldIsoSize; e++) {
+			const int x = i + x_move;
+			const int y = e + y_move;
 
 			if (!isInMap(x, y)) {
 				continue;
 			}
 
 			FIELDDATA& fdd = fielddata[x + y * m_IsoSize];
-			const FIELDDATA& fdo = old_fd.at(i + e * os);
+			const FIELDDATA& fdo = old_fd.at(i + e * oldIsoSize);
 
 			fdd.bCliffHack = fdo.bCliffHack;
 			fdd.bHeight = fdo.bHeight;
@@ -6034,12 +6059,21 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 			fdd.overlay = fdo.overlay;
 			fdd.overlaydata = fdo.overlaydata;
 			fdd.wGround = fdo.wGround;
+			fdd.node = fdo.node;
 		}
 	}
 
 	// MW 07/22/01: Added Progress dialog - it just was slow, and did not crash...
-	int allcount = GetInfantryCount() + GetAircraftCount() + GetUnitCount() + GetStructureCount() + GetTerrainCount() + GetWaypointCount() + GetCelltagCount();
-	int curcount = 0;
+	const int allcount = GetInfantryCount() 
+		+ GetAircraftCount() 
+		+ GetUnitCount() 
+		+ GetStructureCount()
+		+ GetTerrainCount() 
+		+ GetWaypointCount() 
+		+ GetCelltagCount()
+		+ baseNodes.size()
+		;
+	int progress = 0;
 	CProgressDlg* dlg = new(CProgressDlg)("Updating objects, please wait");
 	dlg->SetRange(0, allcount - 1);
 	dlg->ShowWindow(SW_SHOW);
@@ -6061,7 +6095,7 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 	int count = inf_count; // this temp variable is *needed* (infinite loop)!!!
 	for (int i = 0; i < count; i++) {
 		if (inf[i].deleted) {
-			dlg->SetPosition(i + curcount);
+			dlg->SetPosition(i + progress);
 			dlg->UpdateWindow();
 
 			continue; // MW June 12 01
@@ -6076,12 +6110,12 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 		AddInfantry(&obj);
 
-		dlg->SetPosition(i + curcount);
+		dlg->SetPosition(i + progress);
 		dlg->UpdateWindow();
 
 	}
 
-	curcount += count;
+	progress += count;
 
 	count = air_count;
 	for (int i = 0; i < count; i++) {
@@ -6096,13 +6130,13 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 		AddAircraft(&obj);
 
-		dlg->SetPosition(i + curcount);
+		dlg->SetPosition(i + progress);
 		dlg->UpdateWindow();
 	}
 
 	UpdateAircraft(FALSE);
 
-	curcount += count;
+	progress += count;
 
 	count = str_count;
 	for (int i = 0; i < count; i++) {
@@ -6117,13 +6151,13 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 		AddStructure(&obj);
 
-		dlg->SetPosition(i + curcount);
+		dlg->SetPosition(i + progress);
 		dlg->UpdateWindow();
 	}
 
 	UpdateStructures(FALSE);
 
-	curcount += count;
+	progress += count;
 
 	count = unit_count;
 	for (int i = 0; i < count; i++) {
@@ -6138,18 +6172,18 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 		AddUnit(&obj);
 
-		dlg->SetPosition(i + curcount);
+		dlg->SetPosition(i + progress);
 		dlg->UpdateWindow();
 	}
 
 	UpdateUnits(FALSE);
 
-	curcount += count;
+	progress += count;
 
 	count = terrain_count;
 	for (int i = 0; i < count; i++) {
 		if (terrain[i].deleted) {
-			dlg->SetPosition(i + curcount);
+			dlg->SetPosition(i + progress);
 			dlg->UpdateWindow();
 			continue; // MW June 12 01
 		}
@@ -6171,14 +6205,14 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 		AddTerrain(obj, x + y * m_IsoSize);
 
-		dlg->SetPosition(i + curcount);
+		dlg->SetPosition(i + progress);
 		dlg->UpdateWindow();
 	}
 
 	//UpdateTerrain(TRUE);
 	//UpdateTerrain(FALSE);
 
-	curcount += count;
+	progress += count;
 
 	count = wp_count;
 	for (int i = 0; i < count; i++) {
@@ -6188,8 +6222,8 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 		pos = wp_pos[i];
 		id = wp_id[i];
 
-		int x = pos % os + x_move;
-		int y = pos / os + y_move;
+		int x = pos % oldIsoSize + x_move;
+		int y = pos / oldIsoSize + y_move;
 
 		if (!isInMap(x, y)) {
 			continue;
@@ -6197,21 +6231,21 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 		AddWaypoint(id, x + y * m_IsoSize);
 
-		dlg->SetPosition(i + curcount);
+		dlg->SetPosition(i + progress);
 		dlg->UpdateWindow();
 	}
 
 	UpdateWaypoints(FALSE);
 
-	curcount += count;
+	progress += count;
 
 
 	for (int i = 0; i < ct_count; i++) {
 		DWORD pos = ct_pos[i];
 		CString tag = ct_tag[i];
 
-		int x = pos % os + x_move;
-		int y = pos / os + y_move;
+		int x = pos % oldIsoSize + x_move;
+		int y = pos / oldIsoSize + y_move;
 
 		if (!isInMap(x, y)) {
 			continue;
@@ -6219,12 +6253,46 @@ void CMapData::ResizeMap(int iLeft, int iTop, DWORD dwNewWidth, DWORD dwNewHeigh
 
 		AddCelltag(tag, x + y * m_IsoSize);
 
-		dlg->SetPosition(i + curcount);
+		dlg->SetPosition(i + progress);
 		dlg->UpdateWindow();
 	}
+	progress += ct_count;
 
 	UpdateCelltags(FALSE);
 
+	// base nodes
+	if (!baseNodes.empty()) {
+		int progressCounter = 0;
+		CString lastHouse;
+		for (auto& node : baseNodes) {
+			const int x = atoi(node.x) + x_move;
+			const int y = atoi(node.y) + y_move;
+
+			if (!isInMap(x, y)) {
+				continue;
+			}
+			node.x.Format("%d", x);
+			node.y.Format("%d", y);
+
+			if (node.house != lastHouse) {
+				lastHouse = node.house;
+				// first time handling this house, reset
+				if (auto pNodeSec = m_mapfile.TryGetSection(node.house)) {
+					for (auto idx = m_mapfile.GetInteger(node.house, "NodeCount") - 1; idx >= 0; --idx) {
+						DeleteBuildingNodeFrom(node.house, idx, m_mapfile);
+					}
+				}
+			}
+			AddNode(&node, 0, false);
+
+			dlg->SetPosition(progressCounter++ + progress);
+			dlg->UpdateWindow();
+		}
+		progress += progressCounter;
+
+	}
+
+	// data transfer complete!
 	m_noAutoObjectUpdate = FALSE;
 
 	errstream << "Delete old_fd" << endl;

--- a/MissionEditor/MapData.h
+++ b/MissionEditor/MapData.h
@@ -260,6 +260,7 @@ public:
 	DWORD GetStructureCount() const;
 	DWORD GetUnitCount() const;
 	DWORD GetInfantryCount() const;
+	std::vector<NODE> CollectAllBaseNodes() const;
 
 	void GetNthWaypointData(DWORD dwIdx, CString* lpID, DWORD* lpdwPos) const;
 	void GetWaypointData(DWORD dwId, CString* lpID, DWORD* lpdwPos) const;
@@ -293,7 +294,7 @@ public:
 	void InitializeUnitTypes();
 	BOOL AddStructure(STRUCTURE* lpStructure, LPCTSTR lpType = NULL, LPCTSTR lpHouse = NULL, DWORD dwPos = 0, CString suggestedID = "");
 	BOOL AddInfantry(INFANTRY* lpInfantry, int suggestedIndex = -1, LPCTSTR lpType = NULL, LPCTSTR lpHouse = NULL, DWORD dwPos = 0);
-	BOOL AddNode(NODE* lpNode, WORD dwPos);
+	BOOL AddNode(const NODE* lpNode, WORD dwPos, bool reloadAll = true);
 	CString GetNthStructureData(DWORD dwIndex, STRUCTURE* lpStructure) const;
 	void GetStructureData(size_t id, STRUCTURE* lpStructure) const;
 	BOOL AddWaypoint(CString lpID, DWORD dwPos);


### PR DESCRIPTION
地图修改尺寸的时候，没考虑污染标记（地图上的大坑和灼烧）以及基地节点，会直接消失。现在这个改动修复了相关的问题。

测试建议：
1. 测试地图扩大，默认居中的情况
2. 测试地图扩大，单侧扩展，另一侧保持不变的情况
3. 测试地图部分扩大，部分缩小的情况（例如变宽的同时，高度缩小）
4. 测试地图缩小，默认居中
5. 测试地图缩小，类同扩大的测试方法
6. 测试时特别关注边界上存在的物体和地块，看是否正确处理
7. 地图尺寸变更后首先观察主视区是否有不该消失的物体或者地形消失的情况，然后保存地图，再读取地图，观察内容是否出现变化
8. 需要验证地图尺寸变更后，立刻修改相关的属性，例如增删污染标记或是基地节点，首先观察主视区是否存在7中描述的异常现象，然后再保存地图，对比地图内容变化是否存在预期之外的变化