### PR TITLE
Enhance: iso mappack compress

### DIFF
--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -1046,9 +1046,10 @@ void CMapData::Unpack()
 }
 
 uint64_t toUInt64(const MAPFIELDDATA& data) {
+	auto const tileIdx = std::max<short>(static_cast<short>(data.wGround), 0);
 	return (static_cast<uint64_t>(data.wX) << 24) |
 		(static_cast<uint64_t>(data.bHeight) << 16) |
-		(static_cast<uint64_t>(data.wGround));
+		(static_cast<uint64_t>(tileIdx));
 }
 
 std::vector<BYTE> CMapData::compressAndSortMapData(const BYTE* rawData, const size_t rawLen)
@@ -1084,9 +1085,9 @@ std::vector<BYTE> CMapData::compressAndSortMapData(const BYTE* rawData, const si
 
 	assert(ret.size() % MAPFIELDDATA_SIZE == 0);
 	auto const newElementSize = ret.size() / MAPFIELDDATA_SIZE;
-	std::sort(reinterpret_cast<MAPFIELDDATA*>(ret.data()),
+	std::stable_sort(reinterpret_cast<MAPFIELDDATA*>(ret.data()),
 		reinterpret_cast<MAPFIELDDATA*>(ret.data() + ret.size()),
-		[](MAPFIELDDATA& lhs, MAPFIELDDATA& rhs) {
+		[](const MAPFIELDDATA& lhs, const MAPFIELDDATA& rhs) {
 			return toUInt64(lhs) < toUInt64(rhs);
 		}
 	);

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -1045,9 +1045,54 @@ void CMapData::Unpack()
 
 }
 
+uint64_t toUInt64(const MAPFIELDDATA& data) {
+	return (static_cast<uint64_t>(data.wX) << 24) |
+		(static_cast<uint64_t>(data.bHeight) << 16) |
+		(static_cast<uint64_t>(data.wGround));
+}
 
+std::vector<BYTE> CMapData::compressAndSortMapData(const BYTE* rawData, const size_t rawLen)
+{
+	if ((rawLen % MAPFIELDDATA_SIZE) != 0) {
+		throw std::invalid_argument("input data packing err");
+	}
 
+	std::vector<BYTE> ret; 
+	ret.reserve(rawLen);
 
+	auto const elementSize = rawLen / MAPFIELDDATA_SIZE;
+	for (auto idx = 0; idx < elementSize; ++idx) {
+		auto const& fieldData = reinterpret_cast<const MAPFIELDDATA*>(rawData)[idx];
+#if 0 // useless
+		if (lutMap.find(MAKELONG(fieldData.wX, fieldData.wY)) == lutMap.end()) {
+			continue;
+		}
+		auto const fieldDataExt = this->GetFielddataAt(fieldData.wX, fieldData.wY);
+		if (fieldDataExt->wGround < 1 && fieldDataExt->bHeight < 1 && fieldDataExt->bSubTile < 1 && fieldDataExt->bMapData2 < 1) {
+			continue;
+		}
+#endif
+		//auto const tileKey = MAKELONG(fieldData.wGround, fieldData.wTileNum);
+		auto const tileKey = static_cast<short>(fieldData.wGround);
+		if (tileKey < 1 && fieldData.bHeight < 1 && fieldData.bSubTile < 1 && fieldData.bIceGrowth < 1) {
+			continue;
+		}
+		ret.insert(ret.end(),
+			reinterpret_cast<const BYTE*>(&fieldData),
+			reinterpret_cast<const BYTE*>(&fieldData) + MAPFIELDDATA_SIZE);
+	}
+
+	assert(ret.size() % MAPFIELDDATA_SIZE == 0);
+	auto const newElementSize = ret.size() / MAPFIELDDATA_SIZE;
+	std::sort(reinterpret_cast<MAPFIELDDATA*>(ret.data()),
+		reinterpret_cast<MAPFIELDDATA*>(ret.data() + ret.size()),
+		[](MAPFIELDDATA& lhs, MAPFIELDDATA& rhs) {
+			return toUInt64(lhs) < toUInt64(rhs);
+		}
+	);
+
+	return ret;
+}
 
 
 void CMapData::Pack(BOOL bCreatePreview, BOOL bCompression)
@@ -1213,9 +1258,12 @@ void CMapData::Pack(BOOL bCreatePreview, BOOL bCompression)
 	errstream << "Pack isomappack" << endl;
 	errstream.flush();
 
-
-	hexpackedLen = FSunPackLib::EncodeIsoMapPack5(m_mfd, dwIsoMapSize * MAPFIELDDATA_SIZE, &hexpacked);
-
+	auto const mapDataSize = dwIsoMapSize * MAPFIELDDATA_SIZE;
+	{
+		auto const mapRectStr = INIHelper::Split(m_mapfile.GetString("Map", "Size"));
+		auto compressedData = compressAndSortMapData(m_mfd, mapDataSize);
+		hexpackedLen = FSunPackLib::EncodeIsoMapPack5(compressedData.data(), compressedData.size(), &hexpacked);
+	}
 
 	errstream << "done" << endl;
 	errstream.flush();
@@ -3241,8 +3289,9 @@ void CMapData::UpdateMapFieldData(BOOL bSave)
 			if (pos < (GetIsoSize() + 1) * (GetIsoSize() + 1)) {
 				fielddata[pos].wGround = mfd->wGround;
 				fielddata[pos].bHeight = mfd->bHeight;
-				memcpy(&fielddata[pos].bMapData, mfd->bData, 3);
-				memcpy(&fielddata[pos].bMapData2, mfd->bData2, 1);
+				fielddata[pos].bMapData = mfd->wTileNum;
+				fielddata[pos].bSubTile = mfd->bSubTile;
+				fielddata[pos].bMapData2 = mfd->bIceGrowth;
 
 				int replacement = 0;
 				int ground = mfd->wGround;
@@ -3363,8 +3412,8 @@ void CMapData::UpdateMapFieldData(BOOL bSave)
 				mfd->wX = dwY;
 				mfd->wY = dwX;
 				mfd->bHeight = fielddata[i].bHeight;
-				memcpy(&mfd->bData, &fielddata[i].bMapData, 3); // includes fielddata[i].bSubTile!
-				memcpy(&mfd->bData2, &fielddata[i].bMapData2, 1);
+				mfd->wTileNum = fielddata[i].bMapData;
+				mfd->bSubTile = fielddata[i].bSubTile;
 
 				p++;
 			}

--- a/MissionEditor/MapData.h
+++ b/MissionEditor/MapData.h
@@ -77,16 +77,20 @@ struct NODEDATA
 };
 
 // mapfielddata is the data of every field in an extracted isomappack!
+#pragma pack(push, 1)
 struct MAPFIELDDATA
 {
 	unsigned short wX;
 	unsigned short wY;
-	WORD wGround;
-	BYTE bData[3];
+	WORD wGround; // TileIndex
+	WORD wTileNum;
+	BYTE bSubTile;
 	BYTE bHeight;
-	BYTE bData2[1];
+	BYTE bIceGrowth;
 };
-#define MAPFIELDDATA_SIZE 11
+#pragma pack(pop)
+#define MAPFIELDDATA_SIZE sizeof(MAPFIELDDATA)
+static_assert(MAPFIELDDATA_SIZE == 11, "malformed MAPFIELDDATA");
 
 struct StructureData
 {
@@ -520,10 +524,14 @@ public:
 	static CString GetBuildingIDBy(size_t offset);
 
 private:
+	using LUTMap = std::unordered_set<DWORD>;
+
 	void UpdateTubes(BOOL bSave);
 	MAPFIELDDATA* GetMappackPointer(DWORD dwPos);
 
 	void UpdateMapFieldData(BOOL bSave = FALSE);
+
+	std::vector<BYTE> compressAndSortMapData(const BYTE* rawData, const size_t rawLen);
 
 	DWORD m_IsoSize;
 	mutable FIELDDATA outside_f;


### PR DESCRIPTION
Some large maps have too many lines of iso pack data which causing game's incomplete parsing of map data, causing runtime corruption .
Inspired by https://github.com/Starkku/Maptool