### PR TITLE
Feature: CSF Window

### DIFF
--- a/MissionEditor/CsfViewer.cpp
+++ b/MissionEditor/CsfViewer.cpp
@@ -1,0 +1,344 @@
+#include "stdafx.h"
+#include "CsfViewer.h"
+#include "variables.h"
+#include "functions.h"
+
+BEGIN_MESSAGE_MAP(CCsfViewer, CDialog)
+    ON_WM_CLOSE()
+    ON_BN_CLICKED(Controls::Reload, onReload)
+END_MESSAGE_MAP()
+
+#if 0
+LRESULT CALLBACK CCsfViewer::ListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    //return DarkTheme::MyCallWindowProcA(g_pOriginalListViewProc, hWnd, uMsg, wParam, lParam);
+}
+#endif
+
+CCsfViewer::CCsfViewer(CWnd* pParent) : CDialog(CCsfViewer::IDD, pParent)
+{
+}
+CCsfViewer::~CCsfViewer()
+{
+}
+
+BOOL CCsfViewer::OnInitDialog()
+{
+    CDialog::OnInitDialog();
+
+    translateUI();
+
+    return TRUE;  // return TRUE unless you set the focus to a control
+}
+
+void CCsfViewer::DoDataExchange(CDataExchange* pDX)
+{
+    DDX_Control(pDX, Controls::CSFViewer, m_stringList);
+    DDX_Control(pDX, Controls::ItemDetailViewer, m_richEditCtrl);
+    DDX_Control(pDX, Controls::SetLabel, m_selectedLabel);
+    DDX_Control(pDX, Controls::SelectedCSF, m_searchEdit);
+}
+
+void CCsfViewer::translateUI()
+{
+    SetWindowText(GetLanguageStringACP("CsfViewerTitle"));
+    GetDlgItem(1000)->SetWindowText(GetLanguageStringACP("CsfViewerSelectedCsfFile"));
+    GetDlgItem(1002)->SetWindowText(GetLanguageStringACP("CsfViewerNewFile"));
+    GetDlgItem(1003)->SetWindowText(GetLanguageStringACP("CsfViewerSearchLabelText"));
+    GetDlgItem(1005)->SetWindowText(GetLanguageStringACP("CsfViewerAdd"));
+    GetDlgItem(1006)->SetWindowText(GetLanguageStringACP("CsfViewerClone"));
+    GetDlgItem(1007)->SetWindowText(GetLanguageStringACP("CsfViewerDelete"));
+    GetDlgItem(1010)->SetWindowText(GetLanguageStringACP("CsfViewerDescription1"));
+    GetDlgItem(1014)->SetWindowText(GetLanguageStringACP("CsfViewerDescription2"));
+    GetDlgItem(1011)->SetWindowText(GetLanguageStringACP("CsfViewerSave"));
+    GetDlgItem(1012)->SetWindowText(GetLanguageStringACP("CsfViewerSetLabelName"));
+    GetDlgItem(1015)->SetWindowText(GetLanguageStringACP("CsfViewerReload"));
+    GetDlgItem(1016)->SetWindowText(GetLanguageStringACP("CsfViewerApply"));
+
+    SetDlgItemText(IDOK, GetLanguageStringACP("OK"));
+    SetDlgItemText(IDCANCEL, GetLanguageStringACP("Cancel"));
+    m_stringList.SetExtendedStyle(LVS_EX_FULLROWSELECT);
+    m_richEditCtrl.SetReadOnly();
+
+    //ExtraWindow::SetEditControlFontSize(m_richEditCtrl, 1.4f, true);
+    //CFont font();
+    //m_richEditCtrl.SetFont(CFont)
+
+#if 0
+    if (ExtConfigs::EnableDarkMode)
+    {
+        ::SendMessage(m_richEditCtrl, EM_SETBKGNDCOLOR, (WPARAM)FALSE, (LPARAM)RGB(32, 32, 32));
+        CHARFORMAT cf = { 0 };
+        cf.cbSize = sizeof(cf);
+        cf.dwMask = CFM_COLOR;
+        cf.crTextColor = RGB(220, 220, 220);
+        ::SendMessage(m_richEditCtrl, EM_SETCHARFORMAT, SCF_ALL, (LPARAM)&cf);
+        ::SendMessage(hCSFViewer, LVM_SETTEXTBKCOLOR, 0, RGB(32, 32, 32));
+        ::SendMessage(hCSFViewer, LVM_SETTEXTCOLOR, 0, RGB(220, 220, 220));
+
+        DarkTheme::SubclassListViewHeader(hCSFViewer);
+        g_pOriginalListViewProc = (WNDPROC)GetWindowLongPtr(hCSFViewer, GWLP_WNDPROC);
+        if (g_pOriginalListViewProc)
+        {
+            SetWindowLongPtr(hCSFViewer, GWLP_WNDPROC, (LONG_PTR)ListViewSubclassProc);
+        }
+        InvalidateRect(hCSFViewer, NULL, TRUE);
+    }
+
+    Update(hWnd);
+#endif
+}
+
+void CCsfViewer::OnClose()
+{
+    // reduce lag
+    //EndDialog(hWnd, NULL);
+    ShowWindow(SW_HIDE);
+}
+
+void CCsfViewer::onReload()
+{
+    last_succeeded_operation = 9;
+    //StringtableLoader::CSFFiles_Stringtable.clear();
+    //StringtableLoader::LoadCSFFiles();
+    //Logger::Debug("Successfully loaded %d csf labels.\n", StringtableLoader::CSFFiles_Stringtable.size());
+
+    //char tmpCsfFile[0x400];
+    //strcpy_s(tmpCsfFile, CFinalSunAppExt::ExePathExt);
+    //strcat_s(tmpCsfFile, "\\RA2Tmp.csf");
+    //DeleteFile(tmpCsfFile);
+
+    // TODO: reload CSF file
+    //theApp.m_loading->LoadStrings();
+
+    //ExtraWindow::bEnterSearch = true;
+    Update();
+    //ExtraWindow::bEnterSearch = false;
+
+    //UpdateDialog();
+    ((CFinalSunDlg*)theApp.m_pMainWnd)->UpdateDialogs(TRUE);
+}
+
+void CCsfViewer::SetSelectedString(CString str)
+{
+    if (str == CurrentSelectedCSF) {
+        return;
+    }
+    // TODO: reset dialog
+}
+
+void CCsfViewer::Update()
+{
+    displayCSFContent(CCStrings, [](const CString&) { return true; });
+    m_richEditCtrl.SetWindowText("");
+    m_selectedLabel.SetWindowText("");
+    CurrentSelectedCSF = "";
+
+    CString txt;
+    m_searchEdit.GetWindowText(txt);
+    if (!txt.IsEmpty()) {
+        OnEditchangeSearch();
+    }
+    //NeedUpdate = false;
+}
+
+void CCsfViewer::updateTextView()
+{
+    if (CurrentSelectedCSF != "")
+    {
+        auto it = CCStrings.find(CurrentSelectedCSF);
+        if (it != CCStrings.end())
+        {
+            int index = std::distance(CCStrings.begin(), it);
+
+            LVITEM lvItem = { 0 };
+            lvItem.stateMask = LVIS_SELECTED | LVIS_FOCUSED;
+            lvItem.state = LVIS_SELECTED | LVIS_FOCUSED;
+
+            m_stringList.SetItemState(index, &lvItem);
+            m_stringList.EnsureVisible(index, TRUE);
+
+            m_stringList.SetFocus();
+        }
+    }
+    CurrentSelectedCSF = "";
+}
+
+BOOL CCsfViewer::PreTranslateMessage(MSG* pMsg)
+{
+    int ret = -1;
+    if (pMsg->message == WM_KEYDOWN) {
+        ret = onMessageKeyDown(pMsg);
+    }
+
+    return ret < 0 ? this->CDialog::PreTranslateMessage(pMsg) : ret;
+}
+
+BOOL CCsfViewer::onMessageKeyDown(MSG* pMsg)
+{
+    switch (pMsg->wParam) {
+        default:
+            return -1;
+        case VK_RETURN:
+        {
+            switch (::GetDlgCtrlID(pMsg->hwnd)) {
+            default:
+                break;// never exist window (default -1) even nothing did
+            case Controls::Search: this->OnEditchangeSearch();
+                break;
+            }
+        }
+    }
+    return TRUE;
+}
+
+#if 0
+BOOL CALLBACK CCsfViewer::DlgProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (Msg)
+    {
+    case WM_NOTIFY:
+    {
+        LPNMHDR pNMHDR = (LPNMHDR)lParam;
+        if (pNMHDR->idFrom == Controls::CSFViewer && pNMHDR->code == LVN_ITEMCHANGED)
+        {
+            OnViewerSelectedChange(pNMHDR);
+        }
+        else if (pNMHDR->idFrom == Controls::CSFViewer && pNMHDR->code == NM_DBLCLK)
+        {
+            OnClickApply();
+        }
+        break;
+    }
+    case WM_CLOSE:
+    {
+        CCsfViewer::Close(hWnd);
+        return TRUE;
+    }
+    case 114514: // used for update
+    {
+        if (NeedUpdate)
+            Update(hWnd);
+        SetWindowPos(m_hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+        return TRUE;
+    }
+    case 114515: // used for update
+    {
+
+        return TRUE;
+    }
+    case 114516: // used for update
+    {
+        Update(hWnd);
+        return TRUE;
+    }
+    }
+
+    // Process this message through default handler
+    return FALSE;
+}
+#endif
+
+void CCsfViewer::OnViewerSelectedChange()
+{
+    long nStartChar, nEndChar;
+    m_richEditCtrl.GetSel(nStartChar, nEndChar);
+
+    if (nStartChar == nEndChar) {
+        return;
+    }
+
+    CString selectedText = m_richEditCtrl.GetSelText();
+    if (selectedText.IsEmpty()) {
+        m_richEditCtrl.SetWindowText("");
+        m_selectedLabel.SetWindowText("");
+        CurrentSelectedCSF = "";
+        return;
+    }
+
+    CString value = "";
+    auto const it = CCStrings.find(selectedText);
+    if (it == CCStrings.end()) {
+        return;
+    }
+
+    m_richEditCtrl.SetWindowText(it->second.cString);
+    m_selectedLabel.SetWindowText(selectedText);
+
+    CurrentSelectedCSF = selectedText;
+}
+
+// TODO: make it MB_OK
+void CCsfViewer::OnOK()
+{
+    if (CurrentSelectedCSF.IsEmpty()) {
+        return;
+    }
+}
+
+void CCsfViewer::displayCSFContent(const TranslationMap& csfMap, const RowSearchHandler handler)
+{
+    m_stringList.DeleteAllItems();
+    while (m_stringList.DeleteColumn(0));
+
+    CString txt;
+    txt = TranslateStringACP("CsfViewerColumnLabel");
+    LVCOLUMN lvColumn = { 0 };
+    lvColumn.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_SUBITEM;
+    lvColumn.pszText = const_cast<LPSTR>(txt.operator LPCSTR());
+    lvColumn.cx = 100;
+    m_stringList.InsertColumn(0, &lvColumn);
+
+    txt = TranslateStringACP("CsfViewerColumnText");
+    lvColumn.cx = 400;
+    lvColumn.pszText = const_cast<LPSTR>(txt.operator LPCSTR());
+
+    m_stringList.InsertColumn(1, &lvColumn);
+
+    LVITEM lvItem = { 0 };
+    lvItem.mask = LVIF_TEXT;
+
+    int i = 0;
+    for (auto const& [label, content] : csfMap) {
+        if (!handler(label) || !handler(content.cString)) {
+            continue;
+        }
+
+        lvItem.mask = LVIF_TEXT;
+        lvItem.iItem = i;
+        lvItem.iSubItem = 0;
+        lvItem.pszText = const_cast<LPSTR>(label.operator LPCSTR());
+        m_stringList.InsertItem(&lvItem);
+
+        lvItem.iSubItem = 1;
+        lvItem.pszText = const_cast<LPSTR>(content.cString.operator LPCSTR());
+        m_stringList.InsertItem(&lvItem);
+
+        i++;
+    }
+
+    m_stringList.SetColumnWidth(1, LVSCW_AUTOSIZE_USEHEADER);
+}
+
+void CCsfViewer::FilterRows(const CString& searchText)
+{
+    displayCSFContent(CCStrings, [&searchText](const CString& content) {
+        return content.FindOneOf(searchText);
+    });
+}
+
+void CCsfViewer::OnEditchangeSearch()
+{
+    //if (CCStrings.size() > ExtConfigs::SearchCombobox_MaxCount && !ExtraWindow::bEnterSearch)
+    //{
+    //    return;
+    //}
+
+    CString buffer;
+    m_searchEdit.GetWindowTextA(buffer);
+    
+    displayCSFContent(CCStrings, [&buffer](const CString& content) {
+        return buffer.IsEmpty() || content.FindOneOf(buffer);
+    });
+    //NeedUpdate = false;
+}

--- a/MissionEditor/CsfViewer.cpp
+++ b/MissionEditor/CsfViewer.cpp
@@ -6,6 +6,7 @@
 BEGIN_MESSAGE_MAP(CCsfViewer, CDialog)
     ON_WM_CLOSE()
     ON_BN_CLICKED(Controls::Reload, onReload)
+    ON_NOTIFY(LVN_ITEMCHANGED, IDC_CSF_VIEW_LIST, &CCsfViewer::OnViewerSelectedChange)
 END_MESSAGE_MAP()
 
 #if 0
@@ -24,15 +25,21 @@ CCsfViewer::~CCsfViewer()
 
 BOOL CCsfViewer::OnInitDialog()
 {
-    CDialog::OnInitDialog();
+    if (!CDialog::OnInitDialog()) {
+        return FALSE;
+    }
 
     translateUI();
+
+    Reset();
+    onReload();
 
     return TRUE;  // return TRUE unless you set the focus to a control
 }
 
 void CCsfViewer::DoDataExchange(CDataExchange* pDX)
 {
+    CDialog::DoDataExchange(pDX);
     DDX_Control(pDX, Controls::CSFViewer, m_stringList);
     DDX_Control(pDX, Controls::ItemDetailViewer, m_richEditCtrl);
     DDX_Control(pDX, Controls::SetLabel, m_selectedLabel);
@@ -42,21 +49,21 @@ void CCsfViewer::DoDataExchange(CDataExchange* pDX)
 void CCsfViewer::translateUI()
 {
     SetWindowText(GetLanguageStringACP("CsfViewerTitle"));
-    GetDlgItem(1000)->SetWindowText(GetLanguageStringACP("CsfViewerSelectedCsfFile"));
-    GetDlgItem(1002)->SetWindowText(GetLanguageStringACP("CsfViewerNewFile"));
+    //GetDlgItem(1000)->SetWindowText(GetLanguageStringACP("CsfViewerSelectedCsfFile"));
+    //GetDlgItem(1002)->SetWindowText(GetLanguageStringACP("CsfViewerNewFile"));
     GetDlgItem(1003)->SetWindowText(GetLanguageStringACP("CsfViewerSearchLabelText"));
-    GetDlgItem(1005)->SetWindowText(GetLanguageStringACP("CsfViewerAdd"));
-    GetDlgItem(1006)->SetWindowText(GetLanguageStringACP("CsfViewerClone"));
-    GetDlgItem(1007)->SetWindowText(GetLanguageStringACP("CsfViewerDelete"));
+    //GetDlgItem(1005)->SetWindowText(GetLanguageStringACP("CsfViewerAdd"));
+    //GetDlgItem(1006)->SetWindowText(GetLanguageStringACP("CsfViewerClone"));
+    //GetDlgItem(1007)->SetWindowText(GetLanguageStringACP("CsfViewerDelete"));
     GetDlgItem(1010)->SetWindowText(GetLanguageStringACP("CsfViewerDescription1"));
-    GetDlgItem(1014)->SetWindowText(GetLanguageStringACP("CsfViewerDescription2"));
-    GetDlgItem(1011)->SetWindowText(GetLanguageStringACP("CsfViewerSave"));
+    //GetDlgItem(1014)->SetWindowText(GetLanguageStringACP("CsfViewerDescription2"));
+    //GetDlgItem(1011)->SetWindowText(GetLanguageStringACP("CsfViewerSave"));
     GetDlgItem(1012)->SetWindowText(GetLanguageStringACP("CsfViewerSetLabelName"));
-    GetDlgItem(1015)->SetWindowText(GetLanguageStringACP("CsfViewerReload"));
-    GetDlgItem(1016)->SetWindowText(GetLanguageStringACP("CsfViewerApply"));
+    GetDlgItem(Controls::Reload)->SetWindowText(GetLanguageStringACP("CsfViewerReload"));
+    //GetDlgItem(1016)->SetWindowText(GetLanguageStringACP("CsfViewerApply"));
 
     SetDlgItemText(IDOK, GetLanguageStringACP("OK"));
-    SetDlgItemText(IDCANCEL, GetLanguageStringACP("Cancel"));
+    //SetDlgItemText(IDCANCEL, GetLanguageStringACP("Cancel")); // TODO: add cancel
     m_stringList.SetExtendedStyle(LVS_EX_FULLROWSELECT);
     m_richEditCtrl.SetReadOnly();
 
@@ -91,9 +98,10 @@ void CCsfViewer::translateUI()
 
 void CCsfViewer::OnClose()
 {
+    EndDialog(IDCANCEL);
     // reduce lag
     //EndDialog(hWnd, NULL);
-    ShowWindow(SW_HIDE);
+    //ShowWindow(SW_HIDE);
 }
 
 void CCsfViewer::onReload()
@@ -129,7 +137,7 @@ void CCsfViewer::SetSelectedString(CString str)
 
 void CCsfViewer::Update()
 {
-    displayCSFContent(CCStrings, [](const CString&) { return true; });
+    displayCSFContent(AllStrings, [](const CString&) { return true; });
     m_richEditCtrl.SetWindowText("");
     m_selectedLabel.SetWindowText("");
     CurrentSelectedCSF = "";
@@ -146,10 +154,10 @@ void CCsfViewer::updateTextView()
 {
     if (CurrentSelectedCSF != "")
     {
-        auto it = CCStrings.find(CurrentSelectedCSF);
-        if (it != CCStrings.end())
+        auto it = AllStrings.find(CurrentSelectedCSF);
+        if (it != AllStrings.end())
         {
-            int index = std::distance(CCStrings.begin(), it);
+            int index = std::distance(AllStrings.begin(), it);
 
             LVITEM lvItem = { 0 };
             lvItem.stateMask = LVIS_SELECTED | LVIS_FOCUSED;
@@ -177,17 +185,17 @@ BOOL CCsfViewer::PreTranslateMessage(MSG* pMsg)
 BOOL CCsfViewer::onMessageKeyDown(MSG* pMsg)
 {
     switch (pMsg->wParam) {
+    default:
+        return -1;
+    case VK_RETURN:
+    {
+        switch (::GetDlgCtrlID(pMsg->hwnd)) {
         default:
-            return -1;
-        case VK_RETURN:
-        {
-            switch (::GetDlgCtrlID(pMsg->hwnd)) {
-            default:
-                break;// never exist window (default -1) even nothing did
-            case Controls::Search: this->OnEditchangeSearch();
-                break;
-            }
+            break;// never exist window (default -1) even nothing did
+        case Controls::Search: this->OnEditchangeSearch();
+            break;
         }
+    }
     }
     return TRUE;
 }
@@ -239,16 +247,15 @@ BOOL CALLBACK CCsfViewer::DlgProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 }
 #endif
 
-void CCsfViewer::OnViewerSelectedChange()
+void CCsfViewer::OnViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult)
 {
-    long nStartChar, nEndChar;
-    m_richEditCtrl.GetSel(nStartChar, nEndChar);
-
-    if (nStartChar == nEndChar) {
+    int nSelected = m_stringList.GetNextItem(-1, LVNI_SELECTED);
+    if (nSelected == -1) {
         return;
     }
 
-    CString selectedText = m_richEditCtrl.GetSelText();
+    CString selectedText = m_stringList.GetItemText(nSelected, 0);
+
     if (selectedText.IsEmpty()) {
         m_richEditCtrl.SetWindowText("");
         m_selectedLabel.SetWindowText("");
@@ -257,8 +264,8 @@ void CCsfViewer::OnViewerSelectedChange()
     }
 
     CString value = "";
-    auto const it = CCStrings.find(selectedText);
-    if (it == CCStrings.end()) {
+    auto const it = AllStrings.find(selectedText);
+    if (it == AllStrings.end()) {
         return;
     }
 
@@ -266,14 +273,23 @@ void CCsfViewer::OnViewerSelectedChange()
     m_selectedLabel.SetWindowText(selectedText);
 
     CurrentSelectedCSF = selectedText;
+    *pResult = 0;
+}
+
+void CCsfViewer::Reset()
+{
+    m_userConfirmed = false;
+    onReload();
 }
 
 // TODO: make it MB_OK
 void CCsfViewer::OnOK()
 {
     if (CurrentSelectedCSF.IsEmpty()) {
+        EndDialog(IDCANCEL);
         return;
     }
+    EndDialog(IDOK);
 }
 
 void CCsfViewer::displayCSFContent(const TranslationMap& csfMap, const RowSearchHandler handler)
@@ -300,7 +316,7 @@ void CCsfViewer::displayCSFContent(const TranslationMap& csfMap, const RowSearch
 
     int i = 0;
     for (auto const& [label, content] : csfMap) {
-        if (!handler(label) || !handler(content.cString)) {
+        if (!handler(label) && !handler(content.cString)) {
             continue;
         }
 
@@ -310,9 +326,7 @@ void CCsfViewer::displayCSFContent(const TranslationMap& csfMap, const RowSearch
         lvItem.pszText = const_cast<LPSTR>(label.operator LPCSTR());
         m_stringList.InsertItem(&lvItem);
 
-        lvItem.iSubItem = 1;
-        lvItem.pszText = const_cast<LPSTR>(content.cString.operator LPCSTR());
-        m_stringList.InsertItem(&lvItem);
+        m_stringList.SetItemText(i, 1, const_cast<LPSTR>(content.cString.operator LPCSTR()));
 
         i++;
     }
@@ -322,9 +336,9 @@ void CCsfViewer::displayCSFContent(const TranslationMap& csfMap, const RowSearch
 
 void CCsfViewer::FilterRows(const CString& searchText)
 {
-    displayCSFContent(CCStrings, [&searchText](const CString& content) {
+    displayCSFContent(AllStrings, [&searchText](const CString& content) {
         return content.FindOneOf(searchText);
-    });
+        });
 }
 
 void CCsfViewer::OnEditchangeSearch()
@@ -335,10 +349,10 @@ void CCsfViewer::OnEditchangeSearch()
     //}
 
     CString buffer;
-    m_searchEdit.GetWindowTextA(buffer);
-    
-    displayCSFContent(CCStrings, [&buffer](const CString& content) {
-        return buffer.IsEmpty() || content.FindOneOf(buffer);
+    m_searchEdit.GetWindowText(buffer);
+
+    displayCSFContent(AllStrings, [&buffer](const CString& content) {
+        return buffer.IsEmpty() || content.Find(buffer) >= 0;
     });
     //NeedUpdate = false;
 }

--- a/MissionEditor/CsfViewer.cpp
+++ b/MissionEditor/CsfViewer.cpp
@@ -131,27 +131,6 @@ void CCsfViewer::resetControls()
     }
 }
 
-//void CCsfViewer::updateTextView()
-//{
-//    if (m_selectedCSFLabel != "") {
-//        auto it = AllStrings.find(m_selectedCSFLabel);
-//        if (it != AllStrings.end())
-//        {
-//            int index = std::distance(AllStrings.begin(), it);
-//
-//            LVITEM lvItem = { 0 };
-//            lvItem.stateMask = LVIS_SELECTED | LVIS_FOCUSED;
-//            lvItem.state = LVIS_SELECTED | LVIS_FOCUSED;
-//
-//            m_stringList.SetItemState(index, &lvItem);
-//            m_stringList.EnsureVisible(index, TRUE);
-//
-//            m_stringList.SetFocus();
-//        }
-//    }
-//    m_selectedCSFLabel = "";
-//}
-
 BOOL CCsfViewer::PreTranslateMessage(MSG* pMsg)
 {
     int ret = -1;

--- a/MissionEditor/CsfViewer.cpp
+++ b/MissionEditor/CsfViewer.cpp
@@ -89,23 +89,20 @@ void CCsfViewer::translateUI()
         InvalidateRect(hCSFViewer, NULL, TRUE);
     }
 
-    update();
+    resetControls();
 #endif
 }
 
 void CCsfViewer::OnClose()
 {
     EndDialog(IDCANCEL);
-    // reduce lag
-    //EndDialog(hWnd, NULL);
-    //ShowWindow(SW_HIDE);
 }
 
 void CCsfViewer::onReload()
 {
     last_succeeded_operation = 9;
 
-    update();
+    resetControls();
     // this is modal window, no need to update others
     //((CFinalSunDlg*)theApp.m_pMainWnd)->UpdateDialogs(TRUE);
 }
@@ -115,13 +112,14 @@ void CCsfViewer::SetSelectedString(CString str)
     if (str == m_selectedCSFLabel) {
         return;
     }
-    // TODO: reset dialog
+    // NOTE: it does not reset dialog, call applySearch to make it work
     m_selectedCSFLabel = str;
+    m_selectedCSFContent = ""; // reset this value to avoid unwanted cache
 }
 
-void CCsfViewer::update()
+void CCsfViewer::resetControls()
 {
-    displayCSFContent(AllStrings, [](const CString&) { return true; });
+    applySearch();
     m_richEditCtrl.SetWindowText("");
     m_selectedLabel.SetWindowText("");
     m_selectedCSFLabel = "";
@@ -208,6 +206,7 @@ void CCsfViewer::onViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult)
     m_selectedLabel.SetWindowText(selectedText);
 
     m_selectedCSFLabel = selectedText;
+    m_selectedCSFContent = it->second.cString;
     *pResult = 0;
 }
 

--- a/MissionEditor/CsfViewer.cpp
+++ b/MissionEditor/CsfViewer.cpp
@@ -6,7 +6,8 @@
 BEGIN_MESSAGE_MAP(CCsfViewer, CDialog)
     ON_WM_CLOSE()
     ON_BN_CLICKED(Controls::Reload, onReload)
-    ON_NOTIFY(LVN_ITEMCHANGED, IDC_CSF_VIEW_LIST, &CCsfViewer::OnViewerSelectedChange)
+    ON_CBN_KILLFOCUS(IDC_CSF_VIEW_SELECTED, onEditchangeSearch)
+    ON_NOTIFY(LVN_ITEMCHANGED, IDC_CSF_VIEW_LIST, onViewerSelectedChange)
 END_MESSAGE_MAP()
 
 #if 0
@@ -16,7 +17,8 @@ LRESULT CALLBACK CCsfViewer::ListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM w
 }
 #endif
 
-CCsfViewer::CCsfViewer(CWnd* pParent) : CDialog(CCsfViewer::IDD, pParent)
+CCsfViewer::CCsfViewer(CWnd* pParent) 
+    : CDialog(CCsfViewer::IDD, pParent)
 {
 }
 CCsfViewer::~CCsfViewer()
@@ -31,8 +33,10 @@ BOOL CCsfViewer::OnInitDialog()
 
     translateUI();
 
-    Reset();
-    onReload();
+    if (!m_selectedCSFLabel.IsEmpty()) {
+        m_searchEdit.SetWindowText(m_selectedCSFLabel);
+    }
+    onEditchangeSearch();
 
     return TRUE;  // return TRUE unless you set the focus to a control
 }
@@ -49,18 +53,10 @@ void CCsfViewer::DoDataExchange(CDataExchange* pDX)
 void CCsfViewer::translateUI()
 {
     SetWindowText(GetLanguageStringACP("CsfViewerTitle"));
-    //GetDlgItem(1000)->SetWindowText(GetLanguageStringACP("CsfViewerSelectedCsfFile"));
-    //GetDlgItem(1002)->SetWindowText(GetLanguageStringACP("CsfViewerNewFile"));
     GetDlgItem(1003)->SetWindowText(GetLanguageStringACP("CsfViewerSearchLabelText"));
-    //GetDlgItem(1005)->SetWindowText(GetLanguageStringACP("CsfViewerAdd"));
-    //GetDlgItem(1006)->SetWindowText(GetLanguageStringACP("CsfViewerClone"));
-    //GetDlgItem(1007)->SetWindowText(GetLanguageStringACP("CsfViewerDelete"));
     GetDlgItem(1010)->SetWindowText(GetLanguageStringACP("CsfViewerDescription1"));
-    //GetDlgItem(1014)->SetWindowText(GetLanguageStringACP("CsfViewerDescription2"));
-    //GetDlgItem(1011)->SetWindowText(GetLanguageStringACP("CsfViewerSave"));
     GetDlgItem(1012)->SetWindowText(GetLanguageStringACP("CsfViewerSetLabelName"));
     GetDlgItem(Controls::Reload)->SetWindowText(GetLanguageStringACP("CsfViewerReload"));
-    //GetDlgItem(1016)->SetWindowText(GetLanguageStringACP("CsfViewerApply"));
 
     SetDlgItemText(IDOK, GetLanguageStringACP("OK"));
     //SetDlgItemText(IDCANCEL, GetLanguageStringACP("Cancel")); // TODO: add cancel
@@ -68,8 +64,9 @@ void CCsfViewer::translateUI()
     m_richEditCtrl.SetReadOnly();
 
     //ExtraWindow::SetEditControlFontSize(m_richEditCtrl, 1.4f, true);
-    //CFont font();
-    //m_richEditCtrl.SetFont(CFont)
+    CFont font;
+    font.CreatePointFont(100, _T("Tahoma"));
+    m_richEditCtrl.SetFont(&font);
 
 #if 0
     if (ExtConfigs::EnableDarkMode)
@@ -92,7 +89,7 @@ void CCsfViewer::translateUI()
         InvalidateRect(hCSFViewer, NULL, TRUE);
     }
 
-    Update(hWnd);
+    update();
 #endif
 }
 
@@ -107,70 +104,55 @@ void CCsfViewer::OnClose()
 void CCsfViewer::onReload()
 {
     last_succeeded_operation = 9;
-    //StringtableLoader::CSFFiles_Stringtable.clear();
-    //StringtableLoader::LoadCSFFiles();
-    //Logger::Debug("Successfully loaded %d csf labels.\n", StringtableLoader::CSFFiles_Stringtable.size());
 
-    //char tmpCsfFile[0x400];
-    //strcpy_s(tmpCsfFile, CFinalSunAppExt::ExePathExt);
-    //strcat_s(tmpCsfFile, "\\RA2Tmp.csf");
-    //DeleteFile(tmpCsfFile);
-
-    // TODO: reload CSF file
-    //theApp.m_loading->LoadStrings();
-
-    //ExtraWindow::bEnterSearch = true;
-    Update();
-    //ExtraWindow::bEnterSearch = false;
-
-    //UpdateDialog();
-    ((CFinalSunDlg*)theApp.m_pMainWnd)->UpdateDialogs(TRUE);
+    update();
+    // this is modal window, no need to update others
+    //((CFinalSunDlg*)theApp.m_pMainWnd)->UpdateDialogs(TRUE);
 }
 
 void CCsfViewer::SetSelectedString(CString str)
 {
-    if (str == CurrentSelectedCSF) {
+    if (str == m_selectedCSFLabel) {
         return;
     }
     // TODO: reset dialog
+    m_selectedCSFLabel = str;
 }
 
-void CCsfViewer::Update()
+void CCsfViewer::update()
 {
     displayCSFContent(AllStrings, [](const CString&) { return true; });
     m_richEditCtrl.SetWindowText("");
     m_selectedLabel.SetWindowText("");
-    CurrentSelectedCSF = "";
+    m_selectedCSFLabel = "";
 
     CString txt;
     m_searchEdit.GetWindowText(txt);
     if (!txt.IsEmpty()) {
-        OnEditchangeSearch();
+        onEditchangeSearch();
     }
-    //NeedUpdate = false;
 }
 
-void CCsfViewer::updateTextView()
-{
-    if (CurrentSelectedCSF != "")
-    {
-        auto it = AllStrings.find(CurrentSelectedCSF);
-        if (it != AllStrings.end())
-        {
-            int index = std::distance(AllStrings.begin(), it);
-
-            LVITEM lvItem = { 0 };
-            lvItem.stateMask = LVIS_SELECTED | LVIS_FOCUSED;
-            lvItem.state = LVIS_SELECTED | LVIS_FOCUSED;
-
-            m_stringList.SetItemState(index, &lvItem);
-            m_stringList.EnsureVisible(index, TRUE);
-
-            m_stringList.SetFocus();
-        }
-    }
-    CurrentSelectedCSF = "";
-}
+//void CCsfViewer::updateTextView()
+//{
+//    if (m_selectedCSFLabel != "") {
+//        auto it = AllStrings.find(m_selectedCSFLabel);
+//        if (it != AllStrings.end())
+//        {
+//            int index = std::distance(AllStrings.begin(), it);
+//
+//            LVITEM lvItem = { 0 };
+//            lvItem.stateMask = LVIS_SELECTED | LVIS_FOCUSED;
+//            lvItem.state = LVIS_SELECTED | LVIS_FOCUSED;
+//
+//            m_stringList.SetItemState(index, &lvItem);
+//            m_stringList.EnsureVisible(index, TRUE);
+//
+//            m_stringList.SetFocus();
+//        }
+//    }
+//    m_selectedCSFLabel = "";
+//}
 
 BOOL CCsfViewer::PreTranslateMessage(MSG* pMsg)
 {
@@ -192,7 +174,7 @@ BOOL CCsfViewer::onMessageKeyDown(MSG* pMsg)
         switch (::GetDlgCtrlID(pMsg->hwnd)) {
         default:
             break;// never exist window (default -1) even nothing did
-        case Controls::Search: this->OnEditchangeSearch();
+        case Controls::Search: this->onEditchangeSearch();
             break;
         }
     }
@@ -200,54 +182,7 @@ BOOL CCsfViewer::onMessageKeyDown(MSG* pMsg)
     return TRUE;
 }
 
-#if 0
-BOOL CALLBACK CCsfViewer::DlgProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
-{
-    switch (Msg)
-    {
-    case WM_NOTIFY:
-    {
-        LPNMHDR pNMHDR = (LPNMHDR)lParam;
-        if (pNMHDR->idFrom == Controls::CSFViewer && pNMHDR->code == LVN_ITEMCHANGED)
-        {
-            OnViewerSelectedChange(pNMHDR);
-        }
-        else if (pNMHDR->idFrom == Controls::CSFViewer && pNMHDR->code == NM_DBLCLK)
-        {
-            OnClickApply();
-        }
-        break;
-    }
-    case WM_CLOSE:
-    {
-        CCsfViewer::Close(hWnd);
-        return TRUE;
-    }
-    case 114514: // used for update
-    {
-        if (NeedUpdate)
-            Update(hWnd);
-        SetWindowPos(m_hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-        return TRUE;
-    }
-    case 114515: // used for update
-    {
-
-        return TRUE;
-    }
-    case 114516: // used for update
-    {
-        Update(hWnd);
-        return TRUE;
-    }
-    }
-
-    // Process this message through default handler
-    return FALSE;
-}
-#endif
-
-void CCsfViewer::OnViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult)
+void CCsfViewer::onViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult)
 {
     int nSelected = m_stringList.GetNextItem(-1, LVNI_SELECTED);
     if (nSelected == -1) {
@@ -259,7 +194,7 @@ void CCsfViewer::OnViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult)
     if (selectedText.IsEmpty()) {
         m_richEditCtrl.SetWindowText("");
         m_selectedLabel.SetWindowText("");
-        CurrentSelectedCSF = "";
+        m_selectedCSFLabel = "";
         return;
     }
 
@@ -272,20 +207,13 @@ void CCsfViewer::OnViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult)
     m_richEditCtrl.SetWindowText(it->second.cString);
     m_selectedLabel.SetWindowText(selectedText);
 
-    CurrentSelectedCSF = selectedText;
+    m_selectedCSFLabel = selectedText;
     *pResult = 0;
 }
 
-void CCsfViewer::Reset()
-{
-    m_userConfirmed = false;
-    onReload();
-}
-
-// TODO: make it MB_OK
 void CCsfViewer::OnOK()
 {
-    if (CurrentSelectedCSF.IsEmpty()) {
+    if (m_selectedCSFLabel.IsEmpty()) {
         EndDialog(IDCANCEL);
         return;
     }
@@ -334,25 +262,16 @@ void CCsfViewer::displayCSFContent(const TranslationMap& csfMap, const RowSearch
     m_stringList.SetColumnWidth(1, LVSCW_AUTOSIZE_USEHEADER);
 }
 
-void CCsfViewer::FilterRows(const CString& searchText)
+void CCsfViewer::onEditchangeSearch()
 {
-    displayCSFContent(AllStrings, [&searchText](const CString& content) {
-        return content.FindOneOf(searchText);
-        });
-}
-
-void CCsfViewer::OnEditchangeSearch()
-{
-    //if (CCStrings.size() > ExtConfigs::SearchCombobox_MaxCount && !ExtraWindow::bEnterSearch)
-    //{
-    //    return;
-    //}
-
     CString buffer;
     m_searchEdit.GetWindowText(buffer);
+    applySearch(buffer);
+}
 
-    displayCSFContent(AllStrings, [&buffer](const CString& content) {
-        return buffer.IsEmpty() || content.Find(buffer) >= 0;
+void CCsfViewer::applySearch(const CString keyword)
+{
+    displayCSFContent(AllStrings, [&keyword](const CString& content) {
+        return keyword.IsEmpty() || content.Find(keyword) >= 0;
     });
-    //NeedUpdate = false;
 }

--- a/MissionEditor/CsfViewer.h
+++ b/MissionEditor/CsfViewer.h
@@ -27,17 +27,11 @@ public:
 protected:
     enum Controls {
         SelectedCSF = IDC_CSF_VIEW_SELECTED,
-        //NewFile = 1002,
         Search = IDC_CSF_VIEW_SELECTED,
-        //Add = 1005,
-        //Clone = 1006,
-        //Delete = 1007,
         CSFViewer = IDC_CSF_VIEW_LIST,
         ItemDetailViewer = IDC_CSF_VIEW_RICH_EDT,
-        //Save = 1011,
         SetLabel = IDC_CSF_VIEW_CUR_LABEL,
         Reload = IDC_CSF_VIEW_RELOAD,
-        //Apply = 1016
     };
 
     using RowSearchHandler = std::function<bool(const CString&)>;
@@ -53,7 +47,6 @@ protected:
     afx_msg void OnClose();
     afx_msg void onReload();
     void resetControls();
-    //void updateTextView();
     void displayCSFContent(const TranslationMap& csfMap, const RowSearchHandler handler);
     void onEditchangeSearch();
     void applySearch(const CString keyword = {});

--- a/MissionEditor/CsfViewer.h
+++ b/MissionEditor/CsfViewer.h
@@ -19,11 +19,11 @@ public:
     CCsfViewer(CWnd* pParent = nullptr);
     ~CCsfViewer();
 
-    CString CSFLabelSelected() const
-    {
-        return m_selectedCSFLabel;
-    }
+    CString CSFLabelSelected() const { return m_selectedCSFLabel; }
     void SetSelectedString(CString str);
+
+    CString CSFContentSelected() const { return m_selectedCSFContent; }
+
 protected:
     enum Controls {
         SelectedCSF = IDC_CSF_VIEW_SELECTED,
@@ -52,7 +52,7 @@ protected:
 
     afx_msg void OnClose();
     afx_msg void onReload();
-    void update();
+    void resetControls();
     //void updateTextView();
     void displayCSFContent(const TranslationMap& csfMap, const RowSearchHandler handler);
     void onEditchangeSearch();

--- a/MissionEditor/CsfViewer.h
+++ b/MissionEditor/CsfViewer.h
@@ -25,10 +25,12 @@ public:
     }
     void SetSelectedString(CString str);
 
+    void Reset();
+
 protected:
     enum Controls {
-        SelectedCSF = 1001,
-        NewFile = 1002,
+        SelectedCSF = IDC_CSF_VIEW_SELECTED,
+        //NewFile = 1002,
         Search = IDC_CSF_VIEW_SELECTED,
         //Add = 1005,
         //Clone = 1006,
@@ -58,7 +60,7 @@ protected:
     void displayCSFContent(const TranslationMap& csfMap, const RowSearchHandler handler);
     void FilterRows(const CString& searchText);
     void OnEditchangeSearch();
-    void OnViewerSelectedChange();
+    void OnViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult);
     BOOL onMessageKeyDown(MSG* pMsg);
 
     //static BOOL CALLBACK DlgProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
@@ -71,5 +73,6 @@ private:
     CString CurrentSelectedCSF;
     CEdit m_selectedLabel;
     CEdit m_searchEdit;
+    bool m_userConfirmed;
 };
 

--- a/MissionEditor/CsfViewer.h
+++ b/MissionEditor/CsfViewer.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <map>
+#include <vector>
+#include <string>
+#include <regex>
+#include <functional>
+#include <afxrich.h>
+#include "structs.h"
+
+// A static window class
+class CCsfViewer : public CDialog
+{
+public:
+    static LRESULT CALLBACK ListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+    enum { IDD = IDD_CSF_VIEWER };
+
+    CCsfViewer(CWnd* pParent = nullptr);
+    ~CCsfViewer();
+
+    CString CSFLabelSelected() const
+    {
+        return CurrentSelectedCSF;
+    }
+    void SetSelectedString(CString str);
+
+protected:
+    enum Controls {
+        SelectedCSF = 1001,
+        NewFile = 1002,
+        Search = IDC_CSF_VIEW_SELECTED,
+        //Add = 1005,
+        //Clone = 1006,
+        //Delete = 1007,
+        CSFViewer = IDC_CSF_VIEW_LIST,
+        ItemDetailViewer = IDC_CSF_VIEW_RICH_EDT,
+        //Save = 1011,
+        SetLabel = IDC_CSF_VIEW_CUR_LABEL,
+        Reload = IDC_CSF_VIEW_RELOAD,
+        //Apply = 1016
+    };
+
+    using RowSearchHandler = std::function<bool(const CString&)>;
+
+    virtual BOOL OnInitDialog() override;
+    virtual void DoDataExchange(CDataExchange* pDX) override;
+    virtual BOOL PreTranslateMessage(MSG* pMsg) override;
+    virtual void OnOK() override;
+
+    void translateUI();
+
+
+    afx_msg void OnClose();
+    afx_msg void onReload();
+    void Update();
+    void updateTextView();
+    void displayCSFContent(const TranslationMap& csfMap, const RowSearchHandler handler);
+    void FilterRows(const CString& searchText);
+    void OnEditchangeSearch();
+    void OnViewerSelectedChange();
+    BOOL onMessageKeyDown(MSG* pMsg);
+
+    //static BOOL CALLBACK DlgProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+
+    DECLARE_MESSAGE_MAP()
+
+private:
+    CRichEditCtrl m_richEditCtrl;
+    CListCtrl m_stringList;
+    CString CurrentSelectedCSF;
+    CEdit m_selectedLabel;
+    CEdit m_searchEdit;
+};
+

--- a/MissionEditor/CsfViewer.h
+++ b/MissionEditor/CsfViewer.h
@@ -21,12 +21,9 @@ public:
 
     CString CSFLabelSelected() const
     {
-        return CurrentSelectedCSF;
+        return m_selectedCSFLabel;
     }
     void SetSelectedString(CString str);
-
-    void Reset();
-
 protected:
     enum Controls {
         SelectedCSF = IDC_CSF_VIEW_SELECTED,
@@ -55,24 +52,22 @@ protected:
 
     afx_msg void OnClose();
     afx_msg void onReload();
-    void Update();
-    void updateTextView();
+    void update();
+    //void updateTextView();
     void displayCSFContent(const TranslationMap& csfMap, const RowSearchHandler handler);
-    void FilterRows(const CString& searchText);
-    void OnEditchangeSearch();
-    void OnViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult);
+    void onEditchangeSearch();
+    void applySearch(const CString keyword = {});
+    void onViewerSelectedChange(NMHDR* pNMHDR, LRESULT* pResult);
     BOOL onMessageKeyDown(MSG* pMsg);
-
-    //static BOOL CALLBACK DlgProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 
     DECLARE_MESSAGE_MAP()
 
 private:
     CRichEditCtrl m_richEditCtrl;
     CListCtrl m_stringList;
-    CString CurrentSelectedCSF;
     CEdit m_selectedLabel;
     CEdit m_searchEdit;
-    bool m_userConfirmed;
+    CString m_selectedCSFLabel;
+    CString m_selectedCSFContent;
 };
 

--- a/MissionEditor/FinalSun.cpp
+++ b/MissionEditor/FinalSun.cpp
@@ -154,6 +154,11 @@ BOOL CFinalSunApp::InitInstance()
 {
 	m_hAccel = LoadAccelerators(this->m_hInstance, MAKEINTRESOURCE(IDR_MAIN));
 
+	if (!AfxInitRichEdit2()) {
+		::MessageBox(NULL, _T("Failed to initialize RichEdit control"), _T("Error"), MB_ICONERROR);
+		return FALSE;
+	}
+
 #ifndef NOSURFACES
 	if (GetDeviceCaps(GetDC(GetDesktopWindow()), BITSPIXEL) <= 8) {
 		MessageBox(0, "You currently only have 8 bit color mode enabled. This is not recommended. You can continue, but this will cause a significant slowdown while loading graphics, and result in poor graphics quality", "Error", 0);

--- a/MissionEditor/FinalSunDlg.cpp
+++ b/MissionEditor/FinalSunDlg.cpp
@@ -105,7 +105,6 @@ CFinalSunDlg::CFinalSunDlg(CWnd* pParent /*=NULL*/)
 	m_hIcon = AfxGetApp()->LoadIcon(IDR_MAINFRAME);
 	m_hGameCursor = AfxGetApp()->LoadCursor(MAKEINTRESOURCE(IDC_EDITOR_ARROW));
 	m_hArrowCursor = m_hGameCursor;
-
 }
 
 void CFinalSunDlg::DoDataExchange(CDataExchange* pDX)

--- a/MissionEditor/FinalSunDlg.h
+++ b/MissionEditor/FinalSunDlg.h
@@ -45,6 +45,7 @@
 #include "TileSetBrowserFrame.h"	// Hinzugefügt von der Klassenansicht
 #include "ToolSettingsBar.h"
 #include "TriggerEditorDlg.h"
+#include "CsfViewer.h"
 
 #if _MSC_VER > 1000
 #pragma once
@@ -83,6 +84,7 @@ public:
 	CTags m_tags;
 	CTaskForce m_taskforces;
 	CTeamTypes m_teamtypes;
+	CCsfViewer m_csfStrings;
 
 	CHouses m_houses;
 

--- a/MissionEditor/MissionEditor.rc
+++ b/MissionEditor/MissionEditor.rc
@@ -1691,14 +1691,14 @@ END
 IDD_CSF_VIEWER DIALOGEX 0, 0, 357, 329
 STYLE DS_SETFONT | DS_MODALFRAME | WS_CAPTION | WS_SYSMENU
 CAPTION "CSF Viewer"
-FONT 8, "MS Sans Serif", 0, 0, 0x1
+FONT 8, "MS Sans Serif"
 BEGIN
     LTEXT           "Search Label/Text:",1003,7,30,63,8
     EDITTEXT        IDC_CSF_VIEW_SELECTED,77,28,110,13,ES_AUTOHSCROLL
     PUSHBUTTON      "OK",IDOK,231,28,45,13
     PUSHBUTTON      "Reload CSF",IDC_CSF_VIEW_RELOAD,281,28,70,13
     CONTROL         "",IDC_CSF_VIEW_LIST,"SysListView32",LVS_REPORT | WS_BORDER | WS_TABSTOP,7,44,343,176
-    CONTROL         "",IDC_CSF_VIEW_RICH_EDT,"RichEdit20",WS_BORDER | WS_VSCROLL | WS_TABSTOP | 0x4,7,239,343,81
+    CONTROL         "", IDC_CSF_VIEW_RICH_EDT, "RichEdit20A", ES_LEFT | ES_MULTILINE | WS_CHILD | WS_BORDER | WS_VSCROLL | WS_TABSTOP, 7, 239, 343, 81
     LTEXT           "When the trigger editor is to open and the parameter of the selected action is CSF, Click 'Apply' or double click item to apply the currently selected CSF text",1010,7,5,343,18
     LTEXT           "Label Name:",1012,7,226,68,8
     EDITTEXT        IDC_CSF_VIEW_CUR_LABEL,77,223,110,13,ES_AUTOHSCROLL | ES_READONLY

--- a/MissionEditor/MissionEditor.rc
+++ b/MissionEditor/MissionEditor.rc
@@ -1688,6 +1688,22 @@ BEGIN
     COMBOBOX        IDC_COMBO1,7,23,224,160,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 END
 
+IDD_CSF_VIEWER DIALOGEX 0, 0, 357, 329
+STYLE DS_SETFONT | DS_MODALFRAME | WS_CAPTION | WS_SYSMENU
+CAPTION "CSF Viewer"
+FONT 8, "MS Sans Serif", 0, 0, 0x1
+BEGIN
+    LTEXT           "Search Label/Text:",1003,7,30,63,8
+    EDITTEXT        IDC_CSF_VIEW_SELECTED,77,28,110,13,ES_AUTOHSCROLL
+    PUSHBUTTON      "OK",IDOK,231,28,45,13
+    PUSHBUTTON      "Reload CSF",IDC_CSF_VIEW_RELOAD,281,28,70,13
+    CONTROL         "",IDC_CSF_VIEW_LIST,"SysListView32",LVS_REPORT | WS_BORDER | WS_TABSTOP,7,44,343,176
+    CONTROL         "",IDC_CSF_VIEW_RICH_EDT,"RichEdit20",WS_BORDER | WS_VSCROLL | WS_TABSTOP | 0x4,7,239,343,81
+    LTEXT           "When the trigger editor is to open and the parameter of the selected action is CSF, Click 'Apply' or double click item to apply the currently selected CSF text",1010,7,5,343,18
+    LTEXT           "Label Name:",1012,7,226,68,8
+    EDITTEXT        IDC_CSF_VIEW_CUR_LABEL,77,223,110,13,ES_AUTOHSCROLL | ES_READONLY
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -2118,6 +2134,10 @@ BEGIN
         RIGHTMARGIN, 231
         TOPMARGIN, 7
         BOTTOMMARGIN, 56
+    END
+
+    IDD_CSF_VIEWER, DIALOG
+    BEGIN
     END
 END
 #endif    // APSTUDIO_INVOKED
@@ -3643,6 +3663,11 @@ END
 #endif
 
 IDD_CHANGESIZE AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_CSF_VIEWER AFX_DIALOG_LAYOUT
 BEGIN
     0
 END

--- a/MissionEditor/MissionEditor.vcxproj
+++ b/MissionEditor/MissionEditor.vcxproj
@@ -488,6 +488,7 @@
     <ClCompile Include="ChangeSizeDlg.cpp" />
     <ClCompile Include="CliffModifier.cpp" />
     <ClCompile Include="ComboUInputDlg.cpp" />
+    <ClCompile Include="CsfViewer.cpp" />
     <ClCompile Include="DynamicGraphDlg.cpp" />
     <ClCompile Include="FinalSun.cpp" />
     <ClCompile Include="FinalSunDlg.cpp" />
@@ -614,6 +615,7 @@
     <ClInclude Include="ChangeSizeDlg.h" />
     <ClInclude Include="CliffModifier.h" />
     <ClInclude Include="ComboUInputDlg.h" />
+    <ClInclude Include="CsfViewer.h" />
     <ClInclude Include="defines.h" />
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="IniHelper.h" />

--- a/MissionEditor/MissionEditor.vcxproj.filters
+++ b/MissionEditor/MissionEditor.vcxproj.filters
@@ -297,6 +297,9 @@
     <ClCompile Include="MapOperationMiniMap.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CsfViewer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="MissionEditor.rc">
@@ -599,6 +602,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CsfViewer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MissionEditor/Structs.h
+++ b/MissionEditor/Structs.h
@@ -657,6 +657,6 @@ struct RA2STRINGENTRY
 	DWORD value_asc_size;
 };
 
-
+using TranslationMap = map<CString, XCString>;
 
 #endif

--- a/MissionEditor/TriggerActionsDlg.cpp
+++ b/MissionEditor/TriggerActionsDlg.cpp
@@ -277,7 +277,7 @@ void CTriggerActionsDlg::OnEditchangeActiontype()
 	}
 }
 
-CString popUpCSFViewerAndReturn(CComboBox& cb)
+CString CTriggerActionsDlg::popUpCSFViewerAndReturn(CComboBox& cb)
 {
 	CString curValue;
 	cb.GetWindowText(curValue);
@@ -285,20 +285,46 @@ CString popUpCSFViewerAndReturn(CComboBox& cb)
 	auto const pMainDlg = ((CFinalSunDlg*)theApp.m_pMainWnd);
 	auto& csfDlg = pMainDlg->m_csfStrings;
 
+#if defined(MODAL_SIMULATION)
 	if (csfDlg.m_hWnd == NULL) {
-		if (!csfDlg.Create(CCsfViewer::IDD, NULL)) {
+		if (!csfDlg.Create(CCsfViewer::IDD, pMainDlg)) {
 			DWORD dwError = GetLastError();
 			CString errorMsg;
 			errorMsg.Format(_T("Create failed with error code: %lu"), dwError);
 			pMainDlg->MessageBox(GetLanguageStringACP("Err_CreateErr") + errorMsg, "Error");
 		}
 	}
+#endif
 
+	if (csfDlg.m_hWnd == NULL) {
+		// TODO: show error messagebox
+	}
+		//csfDlg.UpdateDialog();
+
+#if !defined(MODAL_SIMULATION)
 	if (csfDlg.DoModal() == IDCANCEL) {
 		return curValue;
 	}
+#else
+	csfDlg.ShowWindow(SW_SHOW);
+	csfDlg.Reset();
+	Sound(SOUND_POSITIVE);
 
-	return curValue;
+	this->EnableWindow(FALSE);
+
+	MSG msg;
+	while (::GetMessageA(&msg, NULL, 0, 0)) {
+		if (!IsDialogMessage(&msg)) {
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	this->EnableWindow(TRUE);
+	//pMainDlg->EnableWindow(TRUE);
+#endif
+
+	return csfDlg.CSFLabelSelected();
 }
 
 void CTriggerActionsDlg::OnSelchangeParameter()
@@ -365,6 +391,7 @@ void CTriggerActionsDlg::OnSelchangeParameter()
 			auto const listTypeIdx = atoi(ListType);
 			if (listTypeIdx == PARAMTYPE_TUTORIALTEXTS) {
 				auto const ret = popUpCSFViewerAndReturn(m_ParamValue);
+				m_ParamValue.SetWindowText(ret);
 				return;
 			}
 			HandleParamList(m_ParamValue, listTypeIdx);

--- a/MissionEditor/TriggerActionsDlg.cpp
+++ b/MissionEditor/TriggerActionsDlg.cpp
@@ -278,23 +278,27 @@ void CTriggerActionsDlg::OnEditchangeActiontype()
 	}
 }
 
-CString CTriggerActionsDlg::popUpCSFViewerAndReturn(CComboBox& cb)
+std::pair<CString, CString> CTriggerActionsDlg::popUpCSFViewerAndReturn(CComboBox& cb)
 {
 	CString curValue;
 	cb.GetWindowText(curValue);
 
-	auto const pMainDlg = ((CFinalSunDlg*)theApp.m_pMainWnd);
-	auto& csfDlg = pMainDlg->m_csfStrings;
+	auto& csfDlg = ((CFinalSunDlg*)theApp.m_pMainWnd)->m_csfStrings;
 
 	if (!curValue.IsEmpty() && curValue != "0") {
+		TruncSpace(curValue);
 		csfDlg.SetSelectedString(curValue);
-	}
-	//csfDlg.UpdateDialog();
-	if (csfDlg.DoModal() == IDCANCEL) {
-		return curValue;
+	} else {
+		csfDlg.SetSelectedString("");
 	}
 
-	return csfDlg.CSFLabelSelected();
+	CString label = csfDlg.DoModal() == IDCANCEL
+		? curValue : csfDlg.CSFLabelSelected();
+
+	auto content = csfDlg.CSFContentSelected();
+	auto const countCorrected = utf8ByteCount(content);
+
+	return { label, content.Left(countCorrected) };
 }
 
 void CTriggerActionsDlg::OnSelchangeParameter()
@@ -508,13 +512,18 @@ void CTriggerActionsDlg::OnDropdownParamvalue()
 		}
 	}
 	
-	auto ret = popUpCSFViewerAndReturn(m_ParamValue);
-	//m_Parameter.SetCurSel(curselparam);
-	m_ParamValue.SetWindowText(ret);
+	auto [label, content] = popUpCSFViewerAndReturn(m_ParamValue);
+	
+	auto txt = label;
+	if (!content.IsEmpty()) {
+		txt += ' ';
+		txt += content;
+	}
+	m_ParamValue.SetWindowText(txt);
+	ini.SetString("Actions", m_currentTrigger, SetParam(ActionData, startpos + 1 + curparam, label));
 
-	ini.SetString("Actions", m_currentTrigger, SetParam(ActionData, startpos + 1 + curparam, ret));
-
-	//m_ParamValue.ShowDropDown();
+	//m_Parameter.SetCurSel(curselparam); no need if 'UpdateDialogs' is not called elsewhere
+	//m_ParamValue.ShowDropDown(); won't work but use Post
 	::PostMessage(m_ParamValue, CB_SHOWDROPDOWN, FALSE, 0);
 }
 

--- a/MissionEditor/TriggerActionsDlg.cpp
+++ b/MissionEditor/TriggerActionsDlg.cpp
@@ -101,6 +101,7 @@ BEGIN_MESSAGE_MAP(CTriggerActionsDlg, CDialog)
 	ON_CBN_SELCHANGE(IDC_ACTION, OnSelchangeAction)
 	ON_CBN_EDITCHANGE(IDC_ACTIONTYPE, OnEditchangeActiontype)
 	ON_LBN_SELCHANGE(IDC_PARAMETER, OnSelchangeParameter)
+	ON_CBN_DROPDOWN(IDC_PARAMVALUE, OnDropdownParamvalue)
 	ON_CBN_EDITCHANGE(IDC_PARAMVALUE, OnEditchangeParamvalue)
 	ON_BN_CLICKED(IDC_NEWACTION, OnNewaction)
 	ON_BN_CLICKED(IDC_DELETEACTION, OnDeleteaction)
@@ -285,44 +286,13 @@ CString CTriggerActionsDlg::popUpCSFViewerAndReturn(CComboBox& cb)
 	auto const pMainDlg = ((CFinalSunDlg*)theApp.m_pMainWnd);
 	auto& csfDlg = pMainDlg->m_csfStrings;
 
-#if defined(MODAL_SIMULATION)
-	if (csfDlg.m_hWnd == NULL) {
-		if (!csfDlg.Create(CCsfViewer::IDD, pMainDlg)) {
-			DWORD dwError = GetLastError();
-			CString errorMsg;
-			errorMsg.Format(_T("Create failed with error code: %lu"), dwError);
-			pMainDlg->MessageBox(GetLanguageStringACP("Err_CreateErr") + errorMsg, "Error");
-		}
+	if (!curValue.IsEmpty() && curValue != "0") {
+		csfDlg.SetSelectedString(curValue);
 	}
-#endif
-
-	if (csfDlg.m_hWnd == NULL) {
-		// TODO: show error messagebox
-	}
-		//csfDlg.UpdateDialog();
-
-#if !defined(MODAL_SIMULATION)
+	//csfDlg.UpdateDialog();
 	if (csfDlg.DoModal() == IDCANCEL) {
 		return curValue;
 	}
-#else
-	csfDlg.ShowWindow(SW_SHOW);
-	csfDlg.Reset();
-	Sound(SOUND_POSITIVE);
-
-	this->EnableWindow(FALSE);
-
-	MSG msg;
-	while (::GetMessageA(&msg, NULL, 0, 0)) {
-		if (!IsDialogMessage(&msg)) {
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-		}
-	}
-
-	this->EnableWindow(TRUE);
-	//pMainDlg->EnableWindow(TRUE);
-#endif
 
 	return csfDlg.CSFLabelSelected();
 }
@@ -390,8 +360,9 @@ void CTriggerActionsDlg::OnSelchangeParameter()
 
 			auto const listTypeIdx = atoi(ListType);
 			if (listTypeIdx == PARAMTYPE_TUTORIALTEXTS) {
-				auto const ret = popUpCSFViewerAndReturn(m_ParamValue);
-				m_ParamValue.SetWindowText(ret);
+				// DO nothing, reacted in selchange or editchange
+				HandleParamList(m_ParamValue, PARAMTYPE_NOTHING);
+				m_ParamValue.SetWindowText(GetParam(ActionData, startpos + 1 + curparam));
 				return;
 			}
 			HandleParamList(m_ParamValue, listTypeIdx);
@@ -474,7 +445,9 @@ void CTriggerActionsDlg::OnEditchangeParamvalue()
 	TruncSpace(newVal);
 	newVal.TrimLeft();
 
-	if (newVal.Find(",", 0) >= 0) newVal.SetAt(newVal.Find(",", 0), 0);
+	if (newVal.Find(",", 0) >= 0) {
+		newVal.SetAt(newVal.Find(",", 0), 0);
+	}
 
 	if (curparam >= 0) {
 		ini.SetString("Actions", m_currentTrigger, SetParam(ActionData, startpos + 1 + curparam, newVal));
@@ -490,6 +463,59 @@ void CTriggerActionsDlg::OnEditchangeParamvalue()
 		ini.SetString("Actions", m_currentTrigger, SetParam(ini["Actions"][m_currentTrigger], pos, (LPCTSTR)waypoint));
 	}
 
+}
+
+void CTriggerActionsDlg::OnDropdownParamvalue()
+{
+	CIniFile& ini = Map->GetIniFile();
+
+	if (m_currentTrigger.GetLength() == 0) {
+		return;
+	}
+	int selev = m_Action.GetCurSel();
+	if (selev < 0) {
+		return;
+	}
+	int curev = m_Action.GetItemData(selev);
+
+	int curselparam = m_Parameter.GetCurSel();
+	if (curselparam < 0) {
+		m_ParamValue.SetWindowText("");
+		return;
+	}
+
+	auto const& ActionData = ini["Actions"][m_currentTrigger];
+	int startpos = 1 + curev * 8;
+	int curparam = m_Parameter.GetItemData(curselparam);
+
+	if (curparam < 0 || curparam >= 6) {
+		return;
+	}
+
+	auto const paramStr = GetParam(ActionData, startpos);
+	CString ParamType = GetParam(g_data["Actions"][paramStr], 1 + curparam);
+#ifdef RA2_MODE
+	if (g_data["ActionsRA2"].Exists(paramStr)) {
+		ParamType = GetParam(g_data["ActionsRA2"][paramStr], 1 + curparam);
+	}
+#endif
+	if (atoi(ParamType) >= 0) {
+		CString ListType = GetParam(g_data["ParamTypes"][ParamType], 1);
+
+		auto const listTypeIdx = atoi(ListType);
+		if (listTypeIdx != PARAMTYPE_TUTORIALTEXTS) {
+			return;
+		}
+	}
+	
+	auto ret = popUpCSFViewerAndReturn(m_ParamValue);
+	//m_Parameter.SetCurSel(curselparam);
+	m_ParamValue.SetWindowText(ret);
+
+	ini.SetString("Actions", m_currentTrigger, SetParam(ActionData, startpos + 1 + curparam, ret));
+
+	//m_ParamValue.ShowDropDown();
+	::PostMessage(m_ParamValue, CB_SHOWDROPDOWN, FALSE, 0);
 }
 
 void CTriggerActionsDlg::OnNewaction()

--- a/MissionEditor/TriggerActionsDlg.cpp
+++ b/MissionEditor/TriggerActionsDlg.cpp
@@ -36,6 +36,7 @@
 static char THIS_FILE[] = __FILE__;
 #endif
 
+extern CFinalSunApp theApp;
 
 BOOL IsWaypointFormat(CString s)
 {
@@ -276,13 +277,41 @@ void CTriggerActionsDlg::OnEditchangeActiontype()
 	}
 }
 
+CString popUpCSFViewerAndReturn(CComboBox& cb)
+{
+	CString curValue;
+	cb.GetWindowText(curValue);
+
+	auto const pMainDlg = ((CFinalSunDlg*)theApp.m_pMainWnd);
+	auto& csfDlg = pMainDlg->m_csfStrings;
+
+	if (csfDlg.m_hWnd == NULL) {
+		if (!csfDlg.Create(CCsfViewer::IDD, NULL)) {
+			DWORD dwError = GetLastError();
+			CString errorMsg;
+			errorMsg.Format(_T("Create failed with error code: %lu"), dwError);
+			pMainDlg->MessageBox(GetLanguageStringACP("Err_CreateErr") + errorMsg, "Error");
+		}
+	}
+
+	if (csfDlg.DoModal() == IDCANCEL) {
+		return curValue;
+	}
+
+	return curValue;
+}
+
 void CTriggerActionsDlg::OnSelchangeParameter()
 {
 	CIniFile& ini = Map->GetIniFile();
 
-	if (m_currentTrigger.GetLength() == 0) return;
+	if (m_currentTrigger.GetLength() == 0) {
+		return;
+	}
 	int selev = m_Action.GetCurSel();
-	if (selev < 0) return;
+	if (selev < 0) {
+		return;
+	}
 	int curev = m_Action.GetItemData(selev);
 
 	int curselparam = m_Parameter.GetCurSel();
@@ -293,7 +322,7 @@ void CTriggerActionsDlg::OnSelchangeParameter()
 
 
 
-	int curparam = m_Parameter.GetItemData(curselparam);
+	const int curparam = m_Parameter.GetItemData(curselparam);
 
 
 
@@ -309,6 +338,20 @@ void CTriggerActionsDlg::OnSelchangeParameter()
 		bNoWP = TRUE;
 	}
 
+	if (curparam == -1) {
+		char wayp[50];
+		if (!bNoWP) {
+			ListWaypoints(m_ParamValue);
+			int iWayp = StringToWaypoint(GetParam(ActionData, startpos + 1 + 6));
+			itoa(iWayp, wayp, 10);
+		} else {
+			strcpy(wayp, GetParam(ActionData, startpos + 1 + 6));
+			HandleParamList(m_ParamValue, PARAMTYPE_NOTHING);
+		}
+		m_ParamValue.SetWindowText(wayp);
+		return;
+	}
+
 	if (curparam >= 0 && curparam < 6) {
 		CString ParamType = GetParam(g_data["Actions"][GetParam(ActionData, startpos)], 1 + curparam);
 #ifdef RA2_MODE
@@ -318,7 +361,13 @@ void CTriggerActionsDlg::OnSelchangeParameter()
 #endif
 		if (atoi(ParamType) >= 0) {
 			CString ListType = GetParam(g_data["ParamTypes"][ParamType], 1);
-			HandleParamList(m_ParamValue, atoi(ListType));
+
+			auto const listTypeIdx = atoi(ListType);
+			if (listTypeIdx == PARAMTYPE_TUTORIALTEXTS) {
+				auto const ret = popUpCSFViewerAndReturn(m_ParamValue);
+				return;
+			}
+			HandleParamList(m_ParamValue, listTypeIdx);
 			m_ParamValue.SetWindowText(GetParam(ActionData, startpos + 1 + curparam));
 
 			int i;
@@ -357,22 +406,6 @@ void CTriggerActionsDlg::OnSelchangeParameter()
 			}*/
 		}
 		return;
-	}
-
-	if (curparam == -1) {
-		char wayp[50];
-		if (!bNoWP) {
-			ListWaypoints(m_ParamValue);
-			int iWayp = StringToWaypoint(GetParam(ActionData, startpos + 1 + 6));
-
-			itoa(iWayp, wayp, 10);
-		} else {
-			strcpy(wayp, GetParam(ActionData, startpos + 1 + 6));
-			HandleParamList(m_ParamValue, 0);
-		}
-
-
-		m_ParamValue.SetWindowText(wayp);
 	}
 }
 

--- a/MissionEditor/TriggerActionsDlg.h
+++ b/MissionEditor/TriggerActionsDlg.h
@@ -69,6 +69,7 @@ protected:
 	afx_msg void OnEditchangeActiontype();
 	afx_msg void OnSelchangeParameter();
 	afx_msg void OnEditchangeParamvalue();
+	afx_msg void OnDropdownParamvalue();
 	afx_msg void OnNewaction();
 	afx_msg void OnDeleteaction();
 	//}}AFX_MSG

--- a/MissionEditor/TriggerActionsDlg.h
+++ b/MissionEditor/TriggerActionsDlg.h
@@ -61,7 +61,8 @@ protected:
 // Implementierung
 protected:
 	void TranslateUI();
-	CString popUpCSFViewerAndReturn(CComboBox& cb);
+	// label, content
+	std::pair<CString, CString> popUpCSFViewerAndReturn(CComboBox& cb);
 
 	// Generierte Nachrichtenzuordnungsfunktionen
 	//{{AFX_MSG(CTriggerActionsDlg)

--- a/MissionEditor/TriggerActionsDlg.h
+++ b/MissionEditor/TriggerActionsDlg.h
@@ -61,6 +61,7 @@ protected:
 // Implementierung
 protected:
 	void TranslateUI();
+	CString popUpCSFViewerAndReturn(CComboBox& cb);
 
 	// Generierte Nachrichtenzuordnungsfunktionen
 	//{{AFX_MSG(CTriggerActionsDlg)

--- a/MissionEditor/TriggerEventsDlg.cpp
+++ b/MissionEditor/TriggerEventsDlg.cpp
@@ -457,9 +457,16 @@ void CTriggerEventsDlg::OnSelchangeParameter()
 	}
 
 	CString ListType = GetParam(g_data["ParamTypes"][ParamType], 1);
+	auto const listTypeIdx = atoi(ListType);
 
-	HandleParamList(m_ParamValue, atoi(ListType));
+	HandleParamList(m_ParamValue, listTypeIdx);
 	m_ParamValue.SetWindowText(GetParam(EventData, startpos + 1 + original_cuparam));
+
+	//if (listTypeIdx == PARAMTYPE_TUTORIALTEXTS) {
+	//	CString csfVal;
+	//	m_ParamValue.GetWindowText()
+	//	return;
+	//}
 
 	int i;
 	BOOL bFound = FALSE;

--- a/MissionEditor/data/FinalAlert2/FALanguage.ini
+++ b/MissionEditor/data/FinalAlert2/FALanguage.ini
@@ -1157,6 +1157,14 @@ OptionsSupportMissionsAndMods=任务包及MOD扩展 (首选)
 OptionsSupportOriginalRA2Only=仅原版游戏
 OptionsPreferFA2TheaterSettings=优选地图编辑器地形设定
 
+; CSF Viewer
+CsfViewerTitle=CSF 浏览器
+CsfViewerDescription1=在搜索框中输入关键词以快速定位词条
+CsfViewerSearchLabelText=关键词:
+CsfViewerReload=重置
+CsfViewerColumnLabel=标签
+CsfViewerColumnText=文本
+
 ; menu strings
 File=文件
 New=新建	Ctrl + N

--- a/MissionEditor/data/FinalAlert2/FALanguage.ini
+++ b/MissionEditor/data/FinalAlert2/FALanguage.ini
@@ -1164,6 +1164,7 @@ CsfViewerSearchLabelText=关键词:
 CsfViewerReload=重置
 CsfViewerColumnLabel=标签
 CsfViewerColumnText=文本
+CsfViewerSetLabelName=当前标签:
 
 ; menu strings
 File=文件

--- a/MissionEditor/functions.cpp
+++ b/MissionEditor/functions.cpp
@@ -41,12 +41,29 @@ bool isValidUtf8(const char* utf8)
 {
 	// wstring_convert and codecvt_utf8_utf16 are deprecated in C++17, fallback to Win32
 	auto utf8Count = strlen(utf8);
-	if (utf8Count == 0)
+	if (utf8Count == 0) {
 		return true;
+	}
 
 	// unterminatedCountWChars will be the count of WChars NOT including the terminating zero (due to passing in utf8.size() instead of -1)
 	auto unterminatedCountWChars = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8, utf8Count, nullptr, 0);
 	return unterminatedCountWChars > 0;
+}
+
+size_t utf8ByteCount(const CString& input)
+{
+	CT2A utf8String(input, CP_UTF8);
+	const char* utf8 = utf8String;
+
+	const size_t utf8Count = strlen(utf8);
+	if (utf8Count == 0) {
+		return 0;
+	}
+	const int wideCharCount = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8, utf8Count, nullptr, 0);
+	if (wideCharCount == 0) {
+		return utf8Count;
+	}
+	return utf8Count;
 }
 
 std::wstring utf8ToUtf16(const std::string& utf8)

--- a/MissionEditor/functions.h
+++ b/MissionEditor/functions.h
@@ -52,6 +52,7 @@ bool RepairTrigger(CString& triggerdata);
 void GetDrawBorder(const BYTE* data, int width, int line, int& left, int& right, unsigned int flags, BOOL* TranspInside = NULL);
 
 // String conversion
+size_t utf8ByteCount(const CString& input);
 std::wstring utf8ToUtf16(const char* utf8);
 std::wstring utf8ToUtf16(const std::string& utf8);
 std::string utf16ToUtf8(const std::wstring& utf16);

--- a/MissionEditor/resource.h
+++ b/MissionEditor/resource.h
@@ -2,6 +2,9 @@
 // Microsoft Visual C++ generated include file.
 // Used by MissionEditor.rc
 //
+#define PRODUCT_VERSION_REVISION        0
+#define PRODUCT_VERSION_MINOR           1
+#define PRODUCT_VERSION_MAJOR           2
 #define IDD_TIBERIANSUNMISSIONEDITOR_DIALOG 102
 #define IDD_FINALSUN_DIALOG             102
 #define IDB_LIGHTBULB                   103
@@ -97,6 +100,7 @@
 #define IDD_USERSCRIPTS                 288
 #define IDD_COMBO_UINPUT                289
 #define IDC_EDITOR_ARROW                299
+#define IDD_CSF_VIEWER                  300
 #define IDC_BULB                        1000
 #define IDC_STARTUP                     1001
 #define IDC_NEXTTIP                     1002
@@ -108,6 +112,7 @@
 #define IDC_CARRYOVERCAP                1012
 #define IDC_MAX                         1012
 #define IDC_ENDOFGAME                   1013
+#define IDC_CSF_VIEW_CUR_LABEL          1013
 #define IDC_NEXTSCENARIO                1014
 #define IDC_ALTNEXTSCENARIO             1015
 #define IDC_SKIPSCORE                   1016
@@ -628,6 +633,11 @@
 #define IDC_CMAPSIZE_TOP_TXT            1552
 #define IDC_CMAPSIZE_NOTE_TXT           1553
 #define IDC_CMAPSIZE_WARNING_TXT        1554
+#define IDC_CSF_VIEW_SELECTED           1555
+#define IDC_CSF_VIEW_RELOAD             1556
+#define IDC_CSF_VIEW_SEARCH_EDT         1557
+#define IDC_CSF_VIEW_LIST               1558
+#define IDC_CSF_VIEW_RICH_EDT           1559
 #define ID_FILE_OPENMAP                 40001
 #define ID_FILE_SAVEAS                  40002
 #define ID_FILE_QUIT                    40003
@@ -722,7 +732,7 @@
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        322
+#define _APS_NEXT_RESOURCE_VALUE        323
 #define _APS_NEXT_COMMAND_VALUE         40144
 #define _APS_NEXT_CONTROL_VALUE         1555
 #define _APS_NEXT_SYMED_VALUE           111

--- a/MissionEditor/variables.h
+++ b/MissionEditor/variables.h
@@ -138,6 +138,7 @@ extern BOOL yr_only[];
 
 extern CString currentOwner;
 extern TranslationMap CCStrings;
+extern TranslationMap AllStrings;
 
 // tileset ids
 extern int cliffset;

--- a/MissionEditor/variables.h
+++ b/MissionEditor/variables.h
@@ -30,7 +30,6 @@
 #include "MapData.h"
 
 class CMapData;
-using TranslationMap = map<CString, XCString>;
 
 // the map
 extern CMapData* Map;


### PR DESCRIPTION
重构触发事件内的CSF选择功能，模仿handama版FA2sp，现在使用独立的模态窗口进行选择、预览和搜索。表现形式和sp版略有不同，布局是直接搬运的。

测试要点如下：
1. 新建触发，新建行为，选择行为11，点击Combobox小三角按钮，弹出文本选择框，可以选择条目或者按X关闭
2. 已经存在的触发，新建行为，同上
3. 已经存在的触发，已有行为，更改到11，其余同上
4. 已经存在的触发，现有11行为，点击文本显示已经存在的标签，点击Combobox小三角按钮，选择或按X关闭
5. 已经存在的触发，现有11行为，不点击小三角，手工编辑文本框内内容
6. 延续4的行为，手工编辑文本内容