### PR TITLE
Fix: wall overlays

### DIFF
--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -1508,7 +1508,17 @@ void CIsoView::OnMouseMove(UINT nFlags, CPoint point)
 			Map->Paste(x, y, AD.z_data);
 			RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
 			Map->Undo();
-		} else if ((AD.mode == ACTIONMODE_PLACE || AD.mode == ACTIONMODE_RANDOMTERRAIN) && (nFlags & ~MK_CONTROL) == 0 && AD.type != 7 && (AD.type != 6 || (AD.type == 6 && ((AD.data >= 30 && AD.data <= 33) || AD.data == 2 || AD.data == 3)))) // everything placing but not overlay!
+		} else if ((AD.mode == ACTIONMODE_PLACE || AD.mode == ACTIONMODE_RANDOMTERRAIN) 
+			&& (nFlags & ~MK_CONTROL) == 0 
+			&& AD.type != 7 
+			&& (AD.type != 6 
+				|| (AD.type == 6 
+					&& ((AD.data >= 30 && AD.data <= 33) 
+						|| AD.data == 2 
+						|| AD.data == 3)
+					)
+				)
+			) // everything placing but not overlay!
 		{
 			FIELDDATA oldData[32][32];
 			//INFANTRY infData[SUBPOS_COUNT][32][32];
@@ -3747,19 +3757,30 @@ void CIsoView::SetError(const char* text)
 int CIsoView::GetOverlayDirection(int x, int y)
 {
 	DWORD dwIsoSize = Map->GetIsoSize();
-	int p = -1;
 	int type = Map->GetOverlayAt(x + y * dwIsoSize);
 
-	BOOL isTrail = FALSE;
-	int i;
-	for (i = 0; i < overlay_count; i++)
-		if (overlay_number[i] == type)
-			if (overlay_trail[i]) isTrail = TRUE;
+	auto const isTrail = overlay_trail.contains(type);
 
-	if (isTrack(type)) // handling a train track
-	{
+	// handling something like a sandbag/wall
+	if (isTrail) {
+		int p = 0;
+		if (Map->GetOverlayAt(x - 1 + (y - 0) * dwIsoSize) == type) {
+			p |= 0x1;
+		}
+		if (Map->GetOverlayAt(x + (y + 1) * dwIsoSize) == type) {
+			p |= 0x2;
+		}
+		if (Map->GetOverlayAt(x + 1 + (y + 0) * dwIsoSize) == type) {
+			p |= 0x4;
+		}
+		if (Map->GetOverlayAt(x + (y - 1) * dwIsoSize) == type) {
+			p |= 0x8;
+		}
+		return p;
+	}
 
-
+	// handling a train track
+	if (isTrack(type)) {
 		if (isTrack(Map->GetOverlayAt((x - 1) + (y - 1) * dwIsoSize)) && isTrack(Map->GetOverlayAt((x + 1) + (y + 1) * dwIsoSize)))
 			return 0;
 		if (isTrack(Map->GetOverlayAt((x + 1) + (y - 1) * dwIsoSize)) && isTrack(Map->GetOverlayAt((x - 1) + (y + 1) * dwIsoSize)))
@@ -3802,17 +3823,9 @@ int CIsoView::GetOverlayDirection(int x, int y)
 			return 3;
 
 		return 0;
-	} else if (isTrail) // handling something like a sandbag
-	{
-		p = 0;
-		if (Map->GetOverlayAt(x - 1 + (y - 0) * dwIsoSize) == type) p |= 0x1;
-		if (Map->GetOverlayAt(x + (y + 1) * dwIsoSize) == type) p |= 0x2;
-		if (Map->GetOverlayAt(x + 1 + (y + 0) * dwIsoSize) == type) p |= 0x4;
-		if (Map->GetOverlayAt(x + (y - 1) * dwIsoSize) == type) p |= 0x8;
-	}
-
-	return p;
-
+	} 
+	
+	return -1;
 }
 
 void CIsoView::HandleTrail(int x, int y)
@@ -3820,28 +3833,28 @@ void CIsoView::HandleTrail(int x, int y)
 	int i, e;
 	int type = Map->GetOverlayAt(x + y * Map->GetIsoSize());
 
-	if (isTrack(type)) // is a track (overlay must be changed)
-	{
-
+	// is a track (overlay must be changed)
+	if (isTrack(type)) {
 		for (i = x - 2; i <= x + 2; i++) {
 			for (e = y - 1; e <= y + 1; e++) {
 				if (isTrack(Map->GetOverlayAt(i + e * Map->GetIsoSize())))
 					Map->SetOverlayAt(i + e * Map->GetIsoSize(), 0x27 + GetOverlayDirection(i, e));
 			}
 		}
-	} else // something like a sandbag (overlaydata must be changed)
-	{
+		return;
+	}
 
-		for (i = x - 2; i <= x + 2; i++) {
-			for (e = y - 1; e <= y + 1; e++) {
-				if (Map->GetOverlayAt(i + e * Map->GetIsoSize()) == type) {
-					int dir = GetOverlayDirection(i, e);
-					if (dir >= 0)	Map->SetOverlayDataAt(i + e * Map->GetIsoSize(), dir);
+	// something like a sandbag (overlaydata must be changed)
+	for (i = x - 2; i <= x + 2; i++) {
+		for (e = y - 1; e <= y + 1; e++) {
+			if (Map->GetOverlayAt(i + e * Map->GetIsoSize()) == type) {
+				int dir = GetOverlayDirection(i, e);
+				if (dir >= 0) {
+					Map->SetOverlayDataAt(i + e * Map->GetIsoSize(), dir);
 				}
 			}
 		}
 	}
-
 }
 
 
@@ -4869,7 +4882,7 @@ void CIsoView::handleMouseActionManageOverlays(int x, int y)
 		int i;
 		for (i = 0; i < overlay_count; i++) {
 			if (overlay_number[i] == AD.data2) {
-				if (overlay_trail[i]) {
+				if (overlay_trail.contains(i)) {
 					// handle trail stuff!
 					HandleTrail(x, y);
 				}

--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -4114,7 +4114,8 @@ void CIsoView::UpdateStatusBar(int x, int y)
 {
 	CString statusbar;//=TranslateStringACP("Ready");
 
-	FIELDDATA m = *Map->GetFielddataAt(x + y * Map->GetIsoSize());
+	auto const positionId = x + y * Map->GetIsoSize();
+	FIELDDATA m = *Map->GetFielddataAt(positionId);
 	if (m.wGround == 0xFFFF) {
 		m.wGround = 0;
 	}
@@ -4132,21 +4133,20 @@ void CIsoView::UpdateStatusBar(int x, int y)
 	}
 
 
-	if (Map->GetOverlayAt(x + y * Map->GetIsoSize()) != 0xFF) {
+	
+	if (auto const overlayTypeIdx = Map->GetOverlayAt(positionId); 
+		overlayTypeIdx != 0xFF) {
 		char ov[50];
-		itoa(Map->GetOverlayAt(x + y * Map->GetIsoSize()), ov, 16);
+		itoa(overlayTypeIdx, ov, 16);
 
-		int i;
 		CString name;
 		name = "0x";
 		name += ov;
-		for (i = 0; i < overlay_count; i++) {
-			if (overlay_number[i] == Map->GetOverlayAt(x + y * Map->GetIsoSize()))
-				name = overlay_name[i];
+
+		if (overlay_trail.contains(overlayTypeIdx)) {
+			name = GetOverlayDisplayName(overlayTypeIdx);
 		}
-
-
-		itoa(Map->GetOverlayDataAt(x + y * Map->GetIsoSize()), ov, 16);
+		itoa(Map->GetOverlayDataAt(positionId), ov, 16);
 
 		statusbar += GetLanguageStringACP("OvrlStatus");
 		statusbar += TranslateStringACP(name);
@@ -4158,26 +4158,26 @@ void CIsoView::UpdateStatusBar(int x, int y)
 	TECHNODATA techno;
 
 	int objId = -1;
-	if (int n = Map->GetTopStructureAt(x + y * Map->GetIsoSize()); n >= 0) {
+	if (int n = Map->GetTopStructureAt(positionId); n >= 0) {
 		type = TechnoType::Building;
 		statusbar = GetLanguageStringACP("StructStatus");
 		objId = n;
 	}
 
-	if (int n = Map->GetUnitAt(x + y * Map->GetIsoSize()); n >= 0) {
+	if (int n = Map->GetUnitAt(positionId); n >= 0) {
 		type = TechnoType::Unit;
 		statusbar = GetLanguageStringACP("UnitStatus");
 		objId = n;
 
 	}
 
-	if (int n = Map->GetAirAt(x + y * Map->GetIsoSize()); n >= 0) {
+	if (int n = Map->GetAirAt(positionId); n >= 0) {
 		type = TechnoType::Aircraft;
 		statusbar = GetLanguageStringACP("AirStatus");
 		objId = n;
 	}
 
-	if (int n = Map->GetInfantryAt(x + y * Map->GetIsoSize()); n >= 0) {
+	if (int n = Map->GetInfantryAt(positionId); n >= 0) {
 		type = TechnoType::Infantry;
 		INFANTRY inf;
 		Map->GetInfantryData(n, &inf);
@@ -4250,7 +4250,7 @@ void CIsoView::UpdateStatusBar(int x, int y)
 	itoa(td.bMapData2[0],c,10);
 	statusbar+=c;*/
 
-	if (int n = Map->GetCelltagAt(x + y * Map->GetIsoSize()); n >= 0) {
+	if (int n = Map->GetCelltagAt(positionId); n >= 0) {
 		CString type;
 		CString name;
 		DWORD pos;

--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -3837,8 +3837,9 @@ void CIsoView::HandleTrail(int x, int y)
 	if (isTrack(type)) {
 		for (i = x - 2; i <= x + 2; i++) {
 			for (e = y - 1; e <= y + 1; e++) {
-				if (isTrack(Map->GetOverlayAt(i + e * Map->GetIsoSize())))
+				if (isTrack(Map->GetOverlayAt(i + e * Map->GetIsoSize()))) {
 					Map->SetOverlayAt(i + e * Map->GetIsoSize(), 0x27 + GetOverlayDirection(i, e));
+				}
 			}
 		}
 		return;
@@ -4879,14 +4880,9 @@ void CIsoView::handleMouseActionManageOverlays(int x, int y)
 	{
 		Map->SetOverlayAt(dwPos, AD.data2);
 		Map->SetOverlayDataAt(dwPos, 0);
-		int i;
-		for (i = 0; i < overlay_count; i++) {
-			if (overlay_number[i] == AD.data2) {
-				if (overlay_trail.contains(i)) {
-					// handle trail stuff!
-					HandleTrail(x, y);
-				}
-			}
+		if (overlay_trail.contains(AD.data2)) {
+			// handle trail stuff!
+			HandleTrail(x, y);
 		}
 	}
 	else if (AD.data == 33) {

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -1401,7 +1401,9 @@ void CMapData::SetOverlayAt(DWORD dwPos, BYTE bValue)
 	int y = dwPos / m_IsoSize;
 	int x = dwPos % m_IsoSize;
 
-	if (y + x * 512 > overlayDataCapacity || dwPos > m_IsoSize * m_IsoSize) return;
+	if (y + x * 512 > overlayDataCapacity || dwPos > m_IsoSize * m_IsoSize) {
+		return;
+	}
 
 	BYTE& ovrl = m_Overlay[y + x * 512];
 	BYTE& ovrld = m_OverlayData[y + x * 512];
@@ -1420,16 +1422,13 @@ void CMapData::SetOverlayAt(DWORD dwPos, BYTE bValue)
 	AddOvrlMoney(ovrl2, ovrld2);
 
 	int i, e;
-	for (i = -1; i < 2; i++)
-		for (e = -1; e < 2; e++)
-			if (i + x > 0 && i + x < m_IsoSize && y + e >= 0 && y + e < m_IsoSize)
+	for (i = -1; i < 2; i++) {
+		for (e = -1; e < 2; e++) {
+			if (i + x > 0 && i + x < m_IsoSize && y + e >= 0 && y + e < m_IsoSize) {
 				SmoothTiberium(dwPos + i + e * m_IsoSize);
-
-
-
-
-
-
+			}
+		}
+	}
 
 	Mini_UpdatePos(x, y, IsMultiplayer());
 

--- a/MissionEditor/ViewObjects.cpp
+++ b/MissionEditor/ViewObjects.cpp
@@ -67,7 +67,6 @@ BEGIN_MESSAGE_MAP(CViewObjects, CTreeView)
 END_MESSAGE_MAP()
 
 extern BOOL overlay_visible[];
-extern BOOL overlay_trail[];
 
 
 extern int overlay_count;
@@ -257,7 +256,9 @@ void CViewObjects::OnSelchanged(NMHDR* pNMHDR, LRESULT* pResult)
 		}
 
 		case 61:
-			if (!tiledata_count) break;
+			if (!tiledata_count) {
+				break;
+			}
 			AD.type = 0;
 			AD.mode = ACTIONMODE_SETTILE;
 			AD.data = 0;
@@ -1097,6 +1098,7 @@ void CViewObjects::UpdateDialog()
 		auto const& unitname = overlayTypeSec.Nth(i).second;
 		if (rules.GetBool(unitname, "Wall") && rules.GetBool(unitname, "Wall.HasConnection", true)) {
 			allowedToList = true;
+			overlay_trail.insert(i);
 		}
 
 		do {

--- a/MissionEditor/ViewObjects.cpp
+++ b/MissionEditor/ViewObjects.cpp
@@ -1084,14 +1084,6 @@ void CViewObjects::UpdateDialog()
 
 	auto const& overlayTypeSec = rules["OverlayTypes"];
 	auto const sizeLimit = std::min<unsigned int>(overlayTypeSec.Size(), 255);
-	auto getOverlayDisplayName = [](const CString& id) -> CString {
-		auto const& uiName = rules.GetString(id, "UIName");
-		auto it = AllStrings.find(uiName);
-		if (it != AllStrings.end()) {
-			return it->second.cString;
-		}
-		return GetLanguageStringACP(id);
-	};
 
 	for (i = 0; i < sizeLimit; i++) {
 		bool allowedToList = false;
@@ -1121,7 +1113,7 @@ void CViewObjects::UpdateDialog()
 #endif
 		} while (0);
 
-		auto const& overlayName = getOverlayDisplayName(unitname);
+		auto const& overlayName = GetOverlayDisplayName(unitname);
 
 		if (allowedToList) {
 			tree.InsertItem(TVIF_PARAM | TVIF_TEXT, overlayName,

--- a/MissionEditor/functions.cpp
+++ b/MissionEditor/functions.cpp
@@ -521,6 +521,25 @@ void TranslateWindowCaption(CWnd& cwnd, const CString& label)
 	}
 }
 
+CString GetOverlayDisplayName(const int typeIndex)
+{
+	if (typeIndex < 0) {
+		return {};
+	}
+	auto const& overlayTypeSec = rules["OverlayTypes"];
+	return GetOverlayDisplayName(overlayTypeSec.Nth(typeIndex).second);
+}
+
+CString GetOverlayDisplayName(const CString& id)
+{
+	auto const& uiName = rules.GetString(id, "UIName");
+	auto it = AllStrings.find(uiName);
+	if (it != AllStrings.end()) {
+		return it->second.cString;
+	}
+	return GetLanguageStringACP(id);
+}
+
 void TruncSpace(string& str)
 {
 	CString cstr = str.data();

--- a/MissionEditor/functions.h
+++ b/MissionEditor/functions.h
@@ -156,6 +156,9 @@ CString TranslateStringACP(WCHAR* u16EnglishString);
 void TranslateDlgItem(CWnd& cwnd, int controlID, const CString& label);
 void TranslateWindowCaption(CWnd& cwnd, const CString& label);
 
+CString GetOverlayDisplayName(const int typeIndex);
+CString GetOverlayDisplayName(const CString& id);
+
 /****************************************
  sound functions [03/16/2001]
  ****************************************/

--- a/MissionEditor/variables.cpp
+++ b/MissionEditor/variables.cpp
@@ -110,15 +110,14 @@ map<CString, BOOL> missingimages;
 vector<CString> rndterrainsrc;
 
 /* Overlay tile data */
+std::unordered_set<int> overlay_trail;
 #ifndef RA2_MODE
 BOOL overlay_visible[] = { TRUE,TRUE,TRUE,FALSE,FALSE, TRUE };
-BOOL overlay_trail[] = { TRUE,TRUE,TRUE,FALSE,FALSE, TRUE };
 BOOL yr_only[] = { FALSE, FALSE, FALSE, FALSE, FALSE, FALSE };
 int overlay_count = 6;
 const std::string editor_name = "FinalSun";
 #else
 BOOL overlay_visible[] = { TRUE,TRUE,TRUE,TRUE,TRUE,TRUE, TRUE, TRUE, TRUE };
-BOOL overlay_trail[] = { TRUE,TRUE,TRUE,TRUE,TRUE,TRUE, TRUE, TRUE, TRUE };
 BOOL yr_only[] = { FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE };
 int overlay_count = 9;
 const std::string editor_name = "FinalAlert 2";

--- a/MissionEditor/variables.h
+++ b/MissionEditor/variables.h
@@ -132,7 +132,6 @@ extern bool bAllowAccessBehindCliffs;
 extern int overlay_count; // number of overlay ids that have additional information
 #if defined(RA2_MODE)
 static constexpr BOOL overlay_trdebug[] = { FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE };
-static constexpr int overlay_number[] = { 0x0,0x2, 0x1a, 0xcb, 0xf1, 0xcc,0xf3,0xf0, 0x27 };
 static constexpr const char* overlay_name[] = {
 	"Sandbags",
 	"Allied Wall",
@@ -146,7 +145,6 @@ static constexpr const char* overlay_name[] = {
 };
 #else
 static constexpr BOOL overlay_trdebug[] = { FALSE,FALSE,FALSE,FALSE,FALSE, FALSE };
-static constexpr int overlay_number[] = { 0x0,0x2, 0x1a, 0x7e, 0xa7, 0x27 };
 static constexpr const char* overlay_name[] = {
 	"Sandbags",
 	"GDI Wall", 

--- a/MissionEditor/variables.h
+++ b/MissionEditor/variables.h
@@ -156,7 +156,7 @@ static constexpr const char* overlay_name[] = {
 	"Tracks" 
 };
 #endif
-extern BOOL overlay_trail[]; // is it handled as trail?
+extern std::unordered_set<int> overlay_trail; // is it handled as trail?
 extern BOOL yr_only[];
 
 


### PR DESCRIPTION
原先围墙是hardcode，前一个PR解除了treectrl的部分，但是在摆放和预览上还是有问题。本修改从摆放、主视区显示、名称显式都做了彻底的改动，并且跳过了多余的循环（其实就是双循环暴力搜索），现在改用unordered_set快速筛选。