### PR TITLE
Fix: a crash during close

### DIFF
--- a/MissionEditor/GlobalObjectPool.cpp
+++ b/MissionEditor/GlobalObjectPool.cpp
@@ -13,3 +13,44 @@ void OverlayCache::ResetAll()
     ZeroMemory(ovrlpics, sizeof(ovrlpics));
 
 }
+
+void ImageCache::ResetAll()
+{
+
+	int e = 0;
+	for (auto it = pics.begin(); it != pics.end(); it++, e++) {
+		try {
+#ifdef NOSURFACES_OBJECTS			
+			if (it->second.bType == PICDATA_TYPE_BMP) {
+				if (auto pPic = std::exchange(it->second.pic, nullptr)) {
+					((LPDIRECTDRAWSURFACE7)pPic)->Release();
+				}
+			}
+			else {
+				if (auto pPic = std::exchange(it->second.pic, nullptr)) {
+					delete[](pPic);
+				}
+				if (auto pBorder = std::exchange(it->second.vborder, nullptr)) {
+					delete[](pBorder);
+				}
+			}
+#else
+			if (i->second.pic != NULL) i->second.pic->Release();
+#endif
+
+			it->second.pic = NULL;
+		}
+		catch (...) {
+			CString err;
+			err = "Access violation while trying to release surface ";
+			char c[6];
+			itoa(e, c, 10);
+			err += c;
+
+			err += "\n";
+			OutputDebugString(err);
+			continue;
+		}
+	}
+	pics.clear();
+}

--- a/MissionEditor/GlobalObjectPool.h
+++ b/MissionEditor/GlobalObjectPool.h
@@ -3,13 +3,15 @@
 #define GLOBAL_OBJECT_POOL_H
 #include "Defines.h"
 #include "Structs.h"
+#include "IniHelper.h"
+#include <unordered_map>
 
 class OverlayCache
 {
 public:
     void ResetAll();
 
-    void Set(size_t overlayId, size_t subSeq, PICDATA* pData)
+    void Set(size_t overlayId, size_t subSeq, const PICDATA* pData)
     {
         // TODO: boundary check
         ovrlpics[overlayId][subSeq] = pData;
@@ -24,7 +26,33 @@ private:
     static auto constexpr OverlayCacheSlots = 0x1000ull;
 
     /* Overlay picture table (maximum overlay count=0xFF) */
-    PICDATA* ovrlpics[OverlayCacheSlots][max_ovrl_img];
+    const PICDATA* ovrlpics[OverlayCacheSlots][max_ovrl_img];
+};
+
+class ImageCache
+{
+public:
+    const PICDATA* Read(const CString& key) const
+    {
+        auto const it = pics.find(key);
+        if (it != pics.end()) {
+            return &it->second;
+        }
+        return nullptr;
+    }
+    PICDATA& Acquire(const CString& key)
+    {
+        auto const [it, _] = pics.try_emplace(key, PICDATA());
+        return it->second;
+    }
+    bool Exists(const CString& key) const { return pics.find(key) != pics.end(); }
+
+    auto Size() const { return pics.size(); }
+
+    void ResetAll();
+
+private:
+    std::unordered_map<CString, PICDATA, CStringHash> pics;
 };
 
 class GlobalObjectPool
@@ -33,9 +61,12 @@ public:
     static GlobalObjectPool& Instance();
 
     auto& Overlays() { return overlays; }
+    auto& Images() { return images; }
 
 private:
     OverlayCache overlays;
+    // all the pictures shown in the mapview
+    ImageCache images;
 };
 
 #endif

--- a/MissionEditor/IniFile.h
+++ b/MissionEditor/IniFile.h
@@ -61,13 +61,6 @@ public:
 	}
 };
 
-struct CStringHash {
-	auto operator()(const CString& sv) const noexcept {
-		std::string_view view(sv.operator LPCSTR(), sv.GetLength());
-		return std::hash<decltype(view)>()(view);
-	}
-};
-
 class CIniFileSection
 {
 public:

--- a/MissionEditor/IniHelper.h
+++ b/MissionEditor/IniHelper.h
@@ -2,6 +2,13 @@
 #include <CString>
 #include <ctype.h>
 
+struct CStringHash {
+	auto operator()(const CString& sv) const noexcept {
+		std::string_view view(sv.GetString(), sv.GetLength());
+		return std::hash<decltype(view)>()(view);
+	}
+};
+
 class INIHelper
 {
 public:

--- a/MissionEditor/IsoView.cpp
+++ b/MissionEditor/IsoView.cpp
@@ -790,7 +790,7 @@ inline void CalculateHouseColorPalette(int house_pal[houseColorRelMax + 1], cons
 There is no need for newpal
 */
 __forceinline void BlitPic(void* dst, int x, int y, int dleft, int dtop, const DDBoundary& boundary, int dright, int dbottom,
-	PICDATA& pd, int* color = NULL, const int* newPal = NULL)//BYTE* src, int swidth, int sheight)
+	const PICDATA& pd, int* color = NULL, const int* newPal = NULL)//BYTE* src, int swidth, int sheight)
 {
 	ASSERT(pd.bType != PICDATA_TYPE_BMP);
 
@@ -3548,26 +3548,12 @@ First checks if a explicite bitmap exists for this tile, if not
 checks if it can be displayed by a standard bitmap.
 For bridges, it also needs the overlaydata.
 */
-inline PICDATA* GetOverlayPic(BYTE ovrl, BYTE ovrldata)
+inline const PICDATA* GetOverlayPic(BYTE ovrl, BYTE ovrldata)
 {
+	CString overlayImageId;
+	overlayImageId.Format("OVRL%d_%d", ovrl, ovrldata);
 
-	char c[50];
-	char d[50];
-	itoa(ovrl, c, 10);
-	itoa(ovrldata, d, 10);
-
-	CString fname = (CString)"OVRL" + c + "_" + d;
-
-	// MessageBox(0,fname,"",0);
-
-	if (pics.find(fname) != pics.end()) {
-		return &pics[fname];
-	}
-
-	//errstream << "pic " << (LPCSTR)fname << " not found" << endl;
-
-
-	return NULL;
+	return GlobalObjectPool::Instance().Images().Read(overlayImageId);
 }
 
 
@@ -5496,7 +5482,7 @@ void CIsoView::DrawMap()
 		}
 	}
 
-
+	auto& images = GlobalObjectPool::Instance().Images();
 	for (u = left; u < right; u++) {
 		for (v = top; v < bottom; v++) {
 			const MapCoords mapCoords(u, v);
@@ -5769,7 +5755,7 @@ void CIsoView::DrawMap()
 								continue;
 							}
 
-							PICDATA pic;
+							const PICDATA* pic = nullptr;
 							int dir = 0;
 							if (rules.GetBool(upg, "Turret")) {
 								dir = (7 - objp.direction / 32) % 8;
@@ -5777,10 +5763,10 @@ void CIsoView::DrawMap()
 							auto const picName = GetUnitPictureFilename(upg, dir);
 
 							if (!picName.IsEmpty()) {
-								pic = pics[picName];
+								pic = images.Read(picName);
 							}
 
-							if (pic.pic == NULL && !missingimages[upg]) {
+							if ((!pic || pic->pic == NULL) && !missingimages[upg]) {
 								SetError("Loading graphics");
 								theApp.m_loading->LoadUnitGraphic(upg);
 								::Map->UpdateBuildingInfo(&upg);
@@ -5789,24 +5775,30 @@ void CIsoView::DrawMap()
 									picNameAfterLoad = GetUnitPictureFilename(upg, 0);
 								}
 								if (!picNameAfterLoad.IsEmpty()) {
-									pic = pics[picNameAfterLoad];
+									pic = images.Read(picNameAfterLoad);
 								}
-								if (pic.pic == NULL) {
+								if (pic->pic == NULL) {
 									missingimages[upg] = TRUE;
 								}
 							}
 
-							if (pic.pic != NULL) {
+							if (pic && pic->pic != NULL) {
 								static const CString LocLookup[3][2] = { {"PowerUp1LocXX", "PowerUp1LocYY"}, {"PowerUp2LocXX", "PowerUp2LocYY"}, {"PowerUp3LocXX", "PowerUp3LocYY"} };
-								const auto drawCoordsPowerUp = drawCoordsBld + ProjectedVec(f_x / 2 - pic.wMaxWidth / 2, -pic.wMaxHeight / 2) + ProjectedVec(
-									atoi(art.GetString(objp.type, LocLookup[upgrade][0])),
-									atoi(art.GetString(objp.type, LocLookup[upgrade][1]))
+								const auto drawCoordsPowerUp = drawCoordsBld + 
+									ProjectedVec(
+										f_x / 2 - pic->wMaxWidth / 2, 
+										-pic->wMaxHeight / 2)
+									+  ProjectedVec(
+										atoi(art.GetString(objp.type, LocLookup[upgrade][0])),
+										atoi(art.GetString(objp.type, LocLookup[upgrade][1]))
 								);
 								// py-=atoi(art.sections[obj.type].values["PowerUp1LocZZ"]); 
 #ifndef NOSURFACES
 								Blit(pic.pic, drawCoordsPowerUp.x, drawCoordsPowerUp.y);
 #else
-								BlitPic(ddsd.lpSurface, drawCoordsPowerUp.x, drawCoordsPowerUp.y, r.left, r.top, DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch }, r.right, r.bottom, pic, &colorref_conv[objp.col]);
+								BlitPic(ddsd.lpSurface, drawCoordsPowerUp.x, drawCoordsPowerUp.y, r.left, r.top, 
+									DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch },
+									r.right, r.bottom, *pic, &colorref_conv[objp.col]);
 #endif
 
 							}
@@ -5909,22 +5901,22 @@ void CIsoView::DrawMap()
 #ifndef NOSURFACES
 				DrawCell(drawCoords.x, drawCoords.y, 1, 1, c);
 #endif
-				PICDATA p;
+				const PICDATA* p = nullptr;
 				if (!lpPicFile.IsEmpty()) {
-					p = pics[lpPicFile];
+					p = images.Read(lpPicFile);
 				}
 
-				if (p.pic == NULL || lpPicFile.GetLength() == 0) {
+				if (!p || p->pic == NULL || lpPicFile.IsEmpty()) {
 					if (!missingimages[obj.basic.type]) {
 						SetError("Loading graphics");
 						theApp.m_loading->LoadUnitGraphic(obj.basic.type);
 						lpPicFile = GetUnitPictureFilename(imageId, facing);
 						if (!lpPicFile.IsEmpty()) {
-							p = pics[lpPicFile];
+							p = images.Read(lpPicFile);
 						}
 					}
 
-					if (p.pic == NULL) {
+					if (!p || p->pic == NULL) {
 #ifndef NOSURFACES
 						Blit(pics["TANK"].pic, drawCoords.x, drawCoords.y);
 						// TextOut(drawx+f_x/4,drawy+f_y/4, obj.type,c);
@@ -5934,16 +5926,21 @@ void CIsoView::DrawMap()
 					}
 				}
 
-				if (p.pic)// we have a picture!
+				if (p && p->pic)// we have a picture!
 				{
-					const auto drawCoordsOffset = (p.bType == PICDATA_TYPE_BMP) ? ProjectedVec((f_y / 4) + p.x, (f_y - p.wHeight) + p.y) - p.drawOffset() :
-						(p.bType == PICDATA_TYPE_SHP) ? ProjectedVec(f_x / 2 - (p.wMaxWidth / 2), f_y / 2 - (p.wMaxHeight / 2)) : ProjectedVec(f_x / 2, f_y / 2) + p.drawOffset();
+					const auto drawCoordsOffset = (p->bType == PICDATA_TYPE_BMP) ? 
+						ProjectedVec((f_y / 4) + p->x, (f_y - p->wHeight) + p->y) - p->drawOffset() :
+						(p->bType == PICDATA_TYPE_SHP) ? 
+							ProjectedVec(f_x / 2 - (p->wMaxWidth / 2), f_y / 2 - (p->wMaxHeight / 2)) : 
+							ProjectedVec(f_x / 2, f_y / 2) + p->drawOffset();
 					auto drawCoordsUnit = drawCoords + drawCoordsOffset;
 
 #ifndef NOSURFACES
 					Blit(p.pic, drawCoordsUnit.x, drawCoordsUnit.y);
 #else
-					BlitPic(ddsd.lpSurface, drawCoordsUnit.x, drawCoordsUnit.y, r.left, r.top, DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch }, r.right, r.bottom, p, &colorref_conv[c]);
+					BlitPic(ddsd.lpSurface, drawCoordsUnit.x, drawCoordsUnit.y, r.left, r.top,
+						DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch },
+						r.right, r.bottom, *p, &colorref_conv[c]);
 #endif
 				}
 			}
@@ -5961,22 +5958,22 @@ void CIsoView::DrawMap()
 #ifndef NOSURFACES
 				DrawCell(drawCoords.x, drawCoords.y, 1, 1, c);
 #endif
-				PICDATA p;
+				const PICDATA* p = nullptr;
 				if (!lpPicFile.IsEmpty()) {
-					p = pics[lpPicFile];
+					p = images.Read(lpPicFile);
 				}
 
-				if (p.pic == NULL) {
+				if (!p && p->pic == NULL) {
 					if (!missingimages[obj.basic.type]) {
 						SetError("Loading graphics");
 						theApp.m_loading->LoadUnitGraphic(obj.basic.type);
 						lpPicFile = GetUnitPictureFilename(theApp.m_loading->GetArtID(obj.basic.type), facing);
 						if (!lpPicFile.IsEmpty()) {
-							p = pics[lpPicFile];
+							p = images.Read(lpPicFile);
 						}
 					}
 
-					if (p.pic == NULL) {
+					if (!p || p->pic == NULL) {
 #ifndef NOSURFACES
 						Blit(pics["TANK"].pic, drawCoords.x, drawCoords.y);
 						//TextOut(drawx+f_x/4,drawy+f_y/4, obj.type,c);
@@ -5986,16 +5983,20 @@ void CIsoView::DrawMap()
 					}
 				}
 
-				if (p.pic)// we have a picture!
+				if (p && p->pic)// we have a picture!
 				{
-					const auto drawCoordsOffset = (p.bType == PICDATA_TYPE_BMP) ? ProjectedVec(f_x / 2 - p.wWidth / 2, f_y - p.wHeight) - p.drawOffset() :
-						(p.bType == PICDATA_TYPE_SHP) ? ProjectedVec(f_x / 2 - (p.wMaxWidth / 2), f_y / 2 - (p.wMaxHeight / 2)) : ProjectedVec(f_x / 2, f_y / 2) + p.drawOffset();
+					const auto drawCoordsOffset = (p->bType == PICDATA_TYPE_BMP) ? 
+						ProjectedVec(f_x / 2 - p->wWidth / 2, f_y - p->wHeight) - p->drawOffset() :
+							(p->bType == PICDATA_TYPE_SHP) ? 
+								ProjectedVec(f_x / 2 - (p->wMaxWidth / 2), f_y / 2 - (p->wMaxHeight / 2)) : 
+								ProjectedVec(f_x / 2, f_y / 2) + p->drawOffset();
 					auto drawCoordsAir = drawCoords + drawCoordsOffset;
 
 #ifndef NOSURFACES
 					Blit(p.pic, drawCoordsAir.x, drawCoordsAir.y);
 #else
-					BlitPic(ddsd.lpSurface, drawCoordsAir.x, drawCoordsAir.y, r.left, r.top, DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch }, r.right, r.bottom, p, &colorref_conv[c]);
+					BlitPic(ddsd.lpSurface, drawCoordsAir.x, drawCoordsAir.y, r.left, r.top, 
+						DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch }, r.right, r.bottom, *p, &colorref_conv[c]);
 #endif
 				}
 			}
@@ -6033,23 +6034,22 @@ void CIsoView::DrawMap()
 					};
 					auto drawCoordsInf = drawCoords + subPosLookup[std::min(ic, 4)];
 
-					PICDATA p;
-
+					const PICDATA* p = nullptr;
 					if (!lpPicFile.IsEmpty()) {
-						p = pics[lpPicFile];
+						p = images.Read(lpPicFile);
 					}
 
-					if (p.pic == NULL) {
+					if (!p || p->pic == NULL) {
 						if (!missingimages[obj.basic.type]) {
 							SetError("Loading graphics");
 							theApp.m_loading->LoadUnitGraphic(obj.basic.type);
 							lpPicFile = GetUnitPictureFilename(imageId, dir);
 							if (!lpPicFile.IsEmpty()) {
-								p = pics[lpPicFile];
+								p = images.Read(lpPicFile);
 							}
 						}
 
-						if (p.pic == NULL) {
+						if (!p || p->pic == NULL) {
 #ifndef NOSURFACES
 							Blit(pics["MAN"].pic, drawCoordsInf.x, drawCoordsInf.y);
 							// TextOut(drawx+f_x/4,drawy+f_y/4, obj.type,c);
@@ -6061,16 +6061,16 @@ void CIsoView::DrawMap()
 
 
 
-					if (p.pic)// we have a picture!
+					if (p && p->pic)// we have a picture!
 					{
-						auto drawCoordsInfShp = drawCoordsInf + ProjectedVec(f_x / 2 - (p.wMaxWidth / 2), f_y / 2 - (p.wMaxHeight / 2));
+						auto drawCoordsInfShp = drawCoordsInf + ProjectedVec(f_x / 2 - (p->wMaxWidth / 2), f_y / 2 - (p->wMaxHeight / 2));
 
 #ifndef NOSURFACES
 						Blit(p.pic, drawCoordsInfShp.x, drawCoordsInfShp.y, p.wWidth, p.wHeight);
 #else
-						BlitPic(ddsd.lpSurface, drawCoordsInfShp.x, drawCoordsInfShp.y, r.left, r.top, DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch }, r.right, r.bottom, p, &colorref_conv[c]);
+						BlitPic(ddsd.lpSurface, drawCoordsInfShp.x, drawCoordsInfShp.y, r.left, r.top, 
+							DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch }, r.right, r.bottom, *p, &colorref_conv[c]);
 #endif
-
 					}
 
 				}
@@ -6081,16 +6081,16 @@ void CIsoView::DrawMap()
 
 				int id = m.terraintype;
 				int w = 1, h = 1;
-				PICDATA pic;
+				const PICDATA* pic = nullptr;
 				if (id > -1 && id < buildingInfoCapacity) {
 					w = treeinfo[id].w;
 					h = treeinfo[id].h;
-					pic = treeinfo[id].pic;
+					pic = &treeinfo[id].pic;
 				}
 
 				//CString lpPicFile=GetUnitPictureFilename(type, 0);				
 
-				if (pic.pic == NULL) {
+				if (!pic || pic->pic == NULL) {
 					CString type;
 					Map->GetTerrainData(m.terrain, &type);
 
@@ -6098,9 +6098,9 @@ void CIsoView::DrawMap()
 						SetError("Loading graphics");
 						theApp.m_loading->LoadUnitGraphic(type);
 						::Map->UpdateTreeInfo(&type);
-						pic = treeinfo[id].pic;
+						pic = &treeinfo[id].pic;
 					}
-					if (pic.pic == NULL) {
+					if (!pic || pic->pic == NULL) {
 #ifndef NOSURFACES
 						Blit(pics["TREE"].pic, drawCoords.x, drawCoords.y - 19);
 #endif
@@ -6108,14 +6108,15 @@ void CIsoView::DrawMap()
 					}
 				}
 
-				if (pic.pic) {
+				if (pic && pic->pic) {
 
-					auto drawCoordsTerrain = drawCoords + ProjectedVec(f_x / 2 - (pic.wMaxWidth / 2), f_y / 2 - 3 - (pic.wMaxHeight / 2));
+					auto drawCoordsTerrain = drawCoords + ProjectedVec(f_x / 2 - (pic->wMaxWidth / 2), f_y / 2 - 3 - (pic->wMaxHeight / 2));
 
 #ifndef NOSURFACES
 					Blit(pic.pic, drawCoordsTerrain.x, drawCoordsTerrain.y);
 #else
-					BlitPic(ddsd.lpSurface, drawCoordsTerrain.x, drawCoordsTerrain.y, r.left, r.top, DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch }, r.right, r.bottom, pic);
+					BlitPic(ddsd.lpSurface, drawCoordsTerrain.x, drawCoordsTerrain.y, r.left, r.top, 
+						DDBoundary{ ddsd.dwWidth, ddsd.dwHeight, ddsd.lPitch }, r.right, r.bottom, *pic);
 
 #endif
 
@@ -6178,7 +6179,8 @@ void CIsoView::DrawMap()
 #ifdef NOSURFACES
 				lpdsBack->Unlock(NULL);
 #endif
-				Blit(reinterpret_cast<LPDIRECTDRAWSURFACE7>(pics["CELLTAG"].pic), drawCoords.x - 1, drawCoords.y - 1);
+				auto picData = GlobalObjectPool::Instance().Images().Read("CELLTAG");
+				Blit(reinterpret_cast<LPDIRECTDRAWSURFACE7>(picData->pic), drawCoords.x - 1, drawCoords.y - 1);
 
 #ifdef NOSURFACES				
 				ddsd = getDDDescBasic(false);
@@ -6238,8 +6240,9 @@ void CIsoView::DrawMap()
 #endif
 
 	// delayed waypoint rendering
+	auto picData = images.Read("FLAG");
 	for (const auto& wp : m_waypoints_to_render) {
-		Blit(reinterpret_cast<LPDIRECTDRAWSURFACE7>(pics["FLAG"].pic), wp.drawx, wp.drawy);
+		Blit(reinterpret_cast<LPDIRECTDRAWSURFACE7>(picData->pic), wp.drawx, wp.drawy);
 	}
 
 	// map tool rendering
@@ -6270,9 +6273,9 @@ void CIsoView::DrawMap()
 	}
 
 	if (rscroll) {
-		const auto& sc = pics["SCROLLCURSOR"];
-		Blit(reinterpret_cast<LPDIRECTDRAWSURFACE7>(sc.pic), 
-			rclick_x * m_viewScale.x + r.left - sc.wWidth / 2, rclick_y * m_viewScale.y + r.top - sc.wHeight / 2);
+		 picData = images.Read("SCROLLCURSOR");
+		Blit(reinterpret_cast<LPDIRECTDRAWSURFACE7>(picData->pic),
+			rclick_x * m_viewScale.x + r.left - picData->wWidth / 2, rclick_y * m_viewScale.y + r.top - picData->wHeight / 2);
 	}
 
 	BlitBackbufferToHighRes(); // lpdsBackHighRes contains the same graphic, but scaled to the whole window

--- a/MissionEditor/Loading.cpp
+++ b/MissionEditor/Loading.cpp
@@ -1716,10 +1716,10 @@ void CLoading::LoadTerrainOrSmudge(const CString& ID)
 	int nMix = this->FindFileInMix(FileName);
 	if (FSunPackLib::XCC_DoesFileExist(FileName, nMix)) {
 		SHPHEADER header;
-		unsigned char* FramesBuffers[1];
+		unsigned char* FramesBuffers = nullptr;
 		FSunPackLib::SetCurrentSHP(FileName, nMix);
 		FSunPackLib::XCC_GetSHPHeader(&header);
-		FSunPackLib::LoadSHPImage(0, 1, &FramesBuffers[0]);
+		FSunPackLib::LoadSHPImage(0, 1, &FramesBuffers);
 		CString DictName;
 		DictName.Format("%s%d", ImageID.operator LPCSTR(), 0);
 		CString PaletteName;
@@ -1730,7 +1730,7 @@ void CLoading::LoadTerrainOrSmudge(const CString& ID)
 			PaletteName = art.GetStringOr(ArtID, "Palette", "iso");
 			GetFullPaletteName(PaletteName, cur_theat);
 		}
-		SetImageData(FramesBuffers[0], DictName, header.cx, header.cy, m_palettes.LoadPalette(PaletteName));
+		SetImageData(FramesBuffers, DictName, header.cx, header.cy, m_palettes.LoadPalette(PaletteName));
 	}
 }
 
@@ -1763,7 +1763,7 @@ void CLoading::LoadVehicleOrAircraft(const CString& ID)
 		int nMix = this->FindFileInMix(FileName);
 		if (FSunPackLib::XCC_DoesFileExist(FileName, nMix)) {
 			SHPHEADER header;
-			unsigned char* FramesBuffers[2];
+			unsigned char* FramesBuffers[2] = { nullptr };
 			FSunPackLib::SetCurrentSHP(FileName, nMix);
 			FSunPackLib::XCC_GetSHPHeader(&header);
 

--- a/MissionEditor/Loading.cpp
+++ b/MissionEditor/Loading.cpp
@@ -1691,13 +1691,13 @@ void CLoading::LoadInfantry(const CString& ID)
 	int nMix = this->FindFileInMix(FileName);
 	if (FSunPackLib::XCC_DoesFileExist(FileName, nMix)) {
 		SHPHEADER header;
-		unsigned char* FramesBuffers = nullptr;
 		FSunPackLib::SetCurrentSHP(FileName, nMix);
 		FSunPackLib::XCC_GetSHPHeader(&header);
 		for (int i = 0; i < 8; ++i) {
 			if (i >= header.c_images) {
 				continue;
 			}
+			unsigned char* FramesBuffers = nullptr;
 			FSunPackLib::LoadSHPImage(framesToRead[i], 1, &FramesBuffers);
 			CString DictName;
 			DictName.Format("%s%d", ImageID, i);
@@ -1763,7 +1763,6 @@ void CLoading::LoadVehicleOrAircraft(const CString& ID)
 		int nMix = this->FindFileInMix(FileName);
 		if (FSunPackLib::XCC_DoesFileExist(FileName, nMix)) {
 			SHPHEADER header;
-			unsigned char* FramesBuffers[2] = { nullptr };
 			FSunPackLib::SetCurrentSHP(FileName, nMix);
 			FSunPackLib::XCC_GetSHPHeader(&header);
 
@@ -1771,6 +1770,7 @@ void CLoading::LoadVehicleOrAircraft(const CString& ID)
 			const int nWalkFrames = art.GetInteger(ArtID, "WalkFrames", 1);
 
 			for (int i = 0; i < 8; ++i) {
+				unsigned char* FramesBuffers[2] = { nullptr };
 				if (!FSunPackLib::LoadSHPImage(framesToRead[i], 1, &FramesBuffers[0])) {
 					break;
 				}
@@ -3294,8 +3294,7 @@ void CLoading::LoadOverlayGraphic(const CString& lpOvrlName_, const int iOvrlNum
 
 
 			// create an array of pointers to directdraw surfaces
-			lpT = new(BYTE * [maxPics]);
-			memset(lpT, 0, sizeof(BYTE) * maxPics);
+			std::vector<BYTE*> lpT(maxPics);
 
 			// if tiberium, change color
 			BOOL bIsBlueTib = FALSE;
@@ -3336,7 +3335,7 @@ void CLoading::LoadOverlayGraphic(const CString& lpOvrlName_, const int iOvrlNum
 			}
 #endif
 
-			FSunPackLib::LoadSHPImage(0, maxPics, lpT);
+			FSunPackLib::LoadSHPImage(0, maxPics, lpT.data());
 
 #ifndef RA2_MODE
 			if (istiberium)
@@ -3415,9 +3414,6 @@ void CLoading::LoadOverlayGraphic(const CString& lpOvrlName_, const int iOvrlNum
 					picData = p;
 				}
 			}
-
-
-			delete[] lpT;
 		}
 
 	}

--- a/MissionEditor/Loading.cpp
+++ b/MissionEditor/Loading.cpp
@@ -41,6 +41,7 @@
 #include <format>
 #include "IniMega.h"
 #include "VoxelDrawer.h"
+#include "GlobalObjectPool.h"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -640,11 +641,8 @@ void CLoading::VXL_Reset()
 }
 
 bool IsImageLoaded(const CString& ID) {
-	auto const it = pics.find(ID);
-	if (it == pics.end()) {
-		return false;
-	}
-	return it->second.pic != nullptr;
+	auto const pData = GlobalObjectPool::Instance().Images().Read(ID);
+	return pData && pData->pic != nullptr;
 }
 
 void GetFullPaletteName(CString& PaletteName, char theater)
@@ -696,7 +694,7 @@ void CLoading::InitPics(CProgressCtrl* prog)
 		if (ff.FindFile(bmps)) {
 
 			BOOL lastFile = FALSE;
-
+			auto& images = GlobalObjectPool::Instance().Images();
 			for (k = 0; k < m_bmp_count + 1; k++) {
 
 				if (ff.FindNextFile() == 0) {
@@ -707,7 +705,7 @@ void CLoading::InitPics(CProgressCtrl* prog)
 
 				try {
 					auto pNewPic = BitmapToSurface(theApp.MainWindow()->m_view.m_isoview->dd, *BitmapFromFile(ff.GetFilePath())).Detach();
-					auto& picData = pics[ff.GetFileName()];
+					auto& picData = images.Acquire(ff.GetFileName());
 					auto pOldPic = std::exchange(picData.pic, pNewPic);
 					if (pOldPic) {
 						reinterpret_cast<IDirectDrawSurface7*>(pOldPic)->Release();
@@ -723,7 +721,7 @@ void CLoading::InitPics(CProgressCtrl* prog)
 					picData.wMaxHeight = desc.dwHeight;
 					picData.bType = PICDATA_TYPE_BMP;
 
-					FSunPackLib::SetColorKey(reinterpret_cast<LPDIRECTDRAWSURFACE7>(pics[ff.GetFileName()].pic), -1);
+					FSunPackLib::SetColorKey(reinterpret_cast<LPDIRECTDRAWSURFACE7>(picData.pic), -1);
 				} catch (const BitmapNotFound&) {
 				}
 			}
@@ -735,7 +733,7 @@ void CLoading::InitPics(CProgressCtrl* prog)
 	try {
 		auto pPic = BitmapToSurface(theApp.MainWindow()->m_view.m_isoview->dd, *BitmapFromResource(IDB_SCROLLCURSOR)).Detach();
 		// This is really dangerous to store a dangling ComPtr
-		auto& scrollCursorSlot = pics["SCROLLCURSOR"];
+		auto& scrollCursorSlot = GlobalObjectPool::Instance().Images().Acquire("SCROLLCURSOR");
 		auto pOldPic = std::exchange(scrollCursorSlot.pic, pPic);
 		if (pOldPic) {
 			reinterpret_cast<IDirectDrawSurface7*>(pOldPic)->Release();
@@ -757,7 +755,7 @@ void CLoading::InitPics(CProgressCtrl* prog)
 
 	try {
 		auto pPic = BitmapToSurface(theApp.MainWindow()->m_view.m_isoview->dd, *BitmapFromResource(IDB_CELLTAG)).Detach();
-		auto& cellTagSlot = pics["CELLTAG"];
+		auto& cellTagSlot = GlobalObjectPool::Instance().Images().Acquire("CELLTAG");
 		auto pOldPic = std::exchange(cellTagSlot.pic, pPic);
 		if (pOldPic) {
 			reinterpret_cast<IDirectDrawSurface7*>(pOldPic)->Release();
@@ -783,7 +781,7 @@ void CLoading::InitPics(CProgressCtrl* prog)
 
 	try {
 		auto pPic = BitmapToSurface(theApp.MainWindow()->m_view.m_isoview->dd, *BitmapFromResource(IDB_FLAG)).Detach();
-		auto& flagSlot = pics["FLAG"];
+		auto& flagSlot = GlobalObjectPool::Instance().Images().Acquire("FLAG");
 		auto pOldPic = std::exchange(flagSlot.pic, pPic);
 		if (pOldPic) {
 			reinterpret_cast<IDirectDrawSurface7*>(pOldPic)->Release();
@@ -816,7 +814,7 @@ void CLoading::InitPics(CProgressCtrl* prog)
 	//auto ddptr = 
 	theApp.MainWindow()->m_view.m_isoview->dd->CreateSurface(&ddsd, &srf, 0);
 
-	auto& htileSlot = pics["HTILE"];
+	auto& htileSlot = GlobalObjectPool::Instance().Images().Acquire("HTILE");
 	auto const pOldHtSurf = reinterpret_cast<LPDIRECTDRAWSURFACE7>(std::exchange(htileSlot.pic, srf));
 	if (pOldHtSurf) {
 		pOldHtSurf->Release();
@@ -866,7 +864,7 @@ void CLoading::InitPics(CProgressCtrl* prog)
 	GlobalMemoryStatusEx(&ms);
 	cs = ms.ullAvailPhys + ms.ullAvailPageFile;
 
-	int piccount = pics.size();
+	int piccount = GlobalObjectPool::Instance().Images().Size();
 
 	errstream << "InitPics() finished and loaded " << piccount << " pictures. Available memory: " << cs << endl;
 	errstream.flush();
@@ -1962,7 +1960,7 @@ void CLoading::LoadVehicleOrAircraft(const CString& ID)
 void CLoading::SetImageData(unsigned char* pBuffer, const CString& NameInDict, int FullWidth, int FullHeight, Palette* pPal, bool forceNoRemap)
 {
 	ASSERT(!NameInDict.IsEmpty());
-	auto& data = pics[NameInDict];
+	auto& data = GlobalObjectPool::Instance().Images().Acquire(NameInDict);
 
 	SetImageData(pBuffer, data, FullWidth, FullHeight, pPal, forceNoRemap);
 }
@@ -3114,16 +3112,13 @@ BOOL CLoading::LoadTile(LPCSTR lpFilename, HMIXFILE hOwner, HTSPALETTE hPalette,
 #endif
 
 #ifdef NOSURFACES_OBJECTS // palettized
-void CLoading::LoadOverlayGraphic(const CString& lpOvrlName_, int iOvrlNum)
+void CLoading::LoadOverlayGraphic(const CString& lpOvrlName_, const int iOvrlNum)
 {
 	last_succeeded_operation = 11;
 
 	SHPHEADER head;
 	char theat = cur_theat;
 	BYTE** lpT = NULL;
-
-	char OvrlID[50];
-	itoa(iOvrlNum, OvrlID, 10);
 
 	HTSPALETTE hPalette = m_palettes.m_hPalIsoTemp;
 	if (cur_theat == 'T') {
@@ -3368,7 +3363,7 @@ void CLoading::LoadOverlayGraphic(const CString& lpOvrlName_, int iOvrlNum)
 				for (i = 0; i < 16; i++)
 					FSunPackLib::SetTSPaletteEntry(hPalette, 0x10 + i, &rgbOld[i], NULL);
 #endif
-
+			CString overlayImageId;
 			for (i = 0; i < maxPics; i++) {
 				SHPIMAGEHEADER imghead;
 				FSunPackLib::XCC_GetSHPImageHeader(i, &imghead);
@@ -3432,8 +3427,12 @@ void CLoading::LoadOverlayGraphic(const CString& lpOvrlName_, int iOvrlNum)
 					p.wMaxHeight = head.cy;
 					p.bType = PICDATA_TYPE_SHP;
 
-
-					pics[(CString)"OVRL" + OvrlID + "_" + ic] = p;
+					overlayImageId.Format("OVRL%d_%d", iOvrlNum, i);
+					auto& picData = GlobalObjectPool::Instance().Images().Acquire(overlayImageId);
+					if (auto pPic = picData.pic) {
+						delete(pPic);
+					}
+					picData = p;
 				}
 			}
 
@@ -3443,14 +3442,12 @@ void CLoading::LoadOverlayGraphic(const CString& lpOvrlName_, int iOvrlNum)
 
 	}
 
-	int i;
-	for (i = 0; i < 0xFF; i++) {
-		char ic[50];
-		itoa(i, ic, 10);
-
-		pics[(CString)"OVRL" + OvrlID + "_" + ic].bTried = true;
+	CString overlayImageId;
+	for (auto i = 0; i < 0xFF; i++) {
+		overlayImageId.Format("OVRL%d_%d", iOvrlNum, i);
+		auto& picData = GlobalObjectPool::Instance().Images().Acquire(overlayImageId);
+		picData.bTried = true;
 	}
-
 
 }
 #endif
@@ -3729,43 +3726,7 @@ void CLoading::FreeAll()
 		tiledata_count = &d_tiledata_count;
 	}
 
-	map<CString, PICDATA>::iterator i = pics.begin();
-	for (int e = 0; e < pics.size(); e++) {
-		try {
-#ifdef NOSURFACES_OBJECTS			
-			if (i->second.bType == PICDATA_TYPE_BMP) {
-				if (auto pPic = std::exchange(i->second.pic, nullptr)) {
-					((LPDIRECTDRAWSURFACE7)pPic)->Release();
-				}
-			} else {
-				if (auto pPic = std::exchange(i->second.pic, nullptr)) {
-					delete[](pPic);
-				}
-				if (auto pBorder = std::exchange(i->second.vborder, nullptr)) {
-					delete[](pBorder);
-				}
-			}
-#else
-			if (i->second.pic != NULL) i->second.pic->Release();
-#endif
-
-			i->second.pic = NULL;
-		} catch (...) {
-			CString err;
-			err = "Access violation while trying to release surface ";
-			char c[6];
-			itoa(e, c, 10);
-			err += c;
-
-			err += "\n";
-			OutputDebugString(err);
-			continue;
-		}
-
-		i++;
-	}
-
-
+	GlobalObjectPool::Instance().Images().ResetAll();
 
 	try {
 		CFinalSunDlg* dlg = theApp.MainWindow();
@@ -4251,7 +4212,8 @@ void CLoading::PrepareUnitGraphic(const CString& lpUnittype)
 			p.bType = PICDATA_TYPE_SHP;
 			p.bTerrain = limited_to_theater;
 
-			auto& picData = pics[image + ic];
+			
+			auto& picData = GlobalObjectPool::Instance().Images().Acquire(image + ic);
 			if (picData.pic) {
 				delete picData.pic;
 			}

--- a/MissionEditor/Loading.cpp
+++ b/MissionEditor/Loading.cpp
@@ -2030,29 +2030,6 @@ void CLoading::SetImageData(unsigned char* pBuffer, PICDATA& pData, const int Fu
 	pData.bHouseColor = true;
 }
 
-void CLoading::LoadBuildingSubGraphic(const CString& subkey, const CIniFileSection& artSection, BOOL bAlwaysSetChar, char theat, HMIXFILE hShpMix, SHPHEADER& shp_h, BYTE*& shp)
-{
-	CString subname = artSection.GetString(subkey);
-	if (subname.GetLength() > 0) {
-		auto res = FindUnitShp(subname, theat, artSection);
-		/*CString subfilename = subname + ".shp";
-
-		if (isTrue(artSection.GetValueByName("NewTheater")) || bAlwaysSetChar || subfilename.GetAt(0) == 'G' || subfilename.GetAt(0) == 'N' || subfilename.GetAt(0) == 'Y' || subfilename.GetAt(0) == 'C')
-		{
-			auto subfilename_theat = subfilename;
-			subfilename_theat.SetAt(1, theat);
-			if (FSunPackLib::XCC_DoesFileExist(subfilename_theat, hShpMix))
-				subfilename = subfilename_theat;
-		}*/
-
-		if (res && FSunPackLib::XCC_DoesFileExist(res->filename, res->mixfile)) {
-			FSunPackLib::SetCurrentSHP(res->filename, res->mixfile);
-			FSunPackLib::XCC_GetSHPHeader(&shp_h);
-			FSunPackLib::LoadSHPImage(0, 1, &shp);
-
-		}
-	}
-}
 #endif
 
 

--- a/MissionEditor/Loading.cpp
+++ b/MissionEditor/Loading.cpp
@@ -1691,10 +1691,13 @@ void CLoading::LoadInfantry(const CString& ID)
 	int nMix = this->FindFileInMix(FileName);
 	if (FSunPackLib::XCC_DoesFileExist(FileName, nMix)) {
 		SHPHEADER header;
-		unsigned char* FramesBuffers;
+		unsigned char* FramesBuffers = nullptr;
 		FSunPackLib::SetCurrentSHP(FileName, nMix);
 		FSunPackLib::XCC_GetSHPHeader(&header);
 		for (int i = 0; i < 8; ++i) {
+			if (i >= header.c_images) {
+				continue;
+			}
 			FSunPackLib::LoadSHPImage(framesToRead[i], 1, &FramesBuffers);
 			CString DictName;
 			DictName.Format("%s%d", ImageID, i);

--- a/MissionEditor/Loading.h
+++ b/MissionEditor/Loading.h
@@ -124,7 +124,7 @@ public:
 	void VXL_Reset();
 	BOOL LoadUnitGraphic(const CString& lpUnittype);
 	void LoadBuildingSubGraphic(const CString& subkey, const CIniFileSection& artSection, BOOL bAlwaysSetChar, char theat, HMIXFILE hShpMix, SHPHEADER& shp_h, BYTE*& shp);
-	void LoadOverlayGraphic(const CString& lpOvrlName, int iOvrlNum);
+	void LoadOverlayGraphic(const CString& lpOvrlName, const int iOvrlNum);
 	void InitVoxelNormalTables();
 	std::optional<FindShpResult> FindUnitShp(const CString& image, char preferred_theat, const CIniFileSection& artSection);
 	char cur_theat;

--- a/MissionEditor/Loading.h
+++ b/MissionEditor/Loading.h
@@ -123,7 +123,6 @@ public:
 	void VXL_GetAndClear(unsigned char*& pBuffer, int* OutWidth, int* OutHeight);
 	void VXL_Reset();
 	BOOL LoadUnitGraphic(const CString& lpUnittype);
-	void LoadBuildingSubGraphic(const CString& subkey, const CIniFileSection& artSection, BOOL bAlwaysSetChar, char theat, HMIXFILE hShpMix, SHPHEADER& shp_h, BYTE*& shp);
 	void LoadOverlayGraphic(const CString& lpOvrlName, const int iOvrlNum);
 	void InitVoxelNormalTables();
 	std::optional<FindShpResult> FindUnitShp(const CString& image, char preferred_theat, const CIniFileSection& artSection);

--- a/MissionEditor/MapData.cpp
+++ b/MissionEditor/MapData.cpp
@@ -645,43 +645,8 @@ void CMapData::LoadMap(const CString& file)
 	theApp.m_loading->Unload();
 	theApp.m_loading->InitMixFiles();
 
-	map<CString, PICDATA>::iterator it = pics.begin();
-	for (int e = 0; e < pics.size(); e++) {
-		try {
-#ifdef NOSURFACES_OBJECTS			
-			if (it->second.bType == PICDATA_TYPE_BMP) {
-				if (auto pPic = std::exchange(it->second.pic, nullptr)) {
-					((LPDIRECTDRAWSURFACE4)pPic)->Release();
-				}
-			} else {
-				if (auto pPic = std::exchange(it->second.pic, nullptr)) {
-					delete[](pPic);
-				}
-				if (auto pBorder = std::exchange(it->second.vborder, nullptr)) {
-					delete[](pBorder);
-				}
-			}
-#else
-			if (it->second.pic != NULL) it->second.pic->Release();
-#endif
+	GlobalObjectPool::Instance().Images().ResetAll();
 
-			it->second.pic = NULL;
-		} catch (...) {
-			CString err;
-			err = "Access violation while trying to release surface ";
-			char c[6];
-			itoa(e, c, 10);
-			err += c;
-
-			err += "\n";
-			OutputDebugString(err);
-			continue;
-		}
-
-		it++;
-	}
-
-	pics.clear();
 	missingimages.clear();
 
 	theApp.m_loading->InitPics();
@@ -3685,10 +3650,10 @@ BuildingFoundation getBuildingFoundation(const CString& artId) {
 void CMapData::UpdateBuildingInfo(const CString* lpUnitType)
 {
 	auto const& rulesGroup = IniMegaFile::GetRules();
+	auto const& images = GlobalObjectPool::Instance().Images();
 
 	if (!lpUnitType) {
 		memset(buildinginfo, 0, buildingInfoCapacity * sizeof(BUILDING_INFO));
-
 		for (auto const& [seq, id] : rulesGroup.GetSection("BuildingTypes")) {
 			auto const& type = id;
 			auto artname = rulesGroup.GetStringOr(type, "Image", type);
@@ -3709,16 +3674,16 @@ void CMapData::UpdateBuildingInfo(const CString* lpUnitType)
 
 				CString lpPicFile = GetUnitPictureFilename(type, 0);
 
-				if (pics.find(lpPicFile) != pics.end()) {
-					if (pics[lpPicFile].bTerrain == TheaterChar::None) {
+				if (auto const pPicData = images.Read(lpPicFile)) {
+					if (pPicData->bTerrain == TheaterChar::None) {
 						buildinginfo[n].bSnow = TRUE;
 						buildinginfo[n].bTemp = TRUE;
 						buildinginfo[n].bUrban = TRUE;
-					} else if (pics[lpPicFile].bTerrain == TheaterChar::T) {
+					} else if (pPicData->bTerrain == TheaterChar::T) {
 						buildinginfo[n].bTemp = TRUE;
-					} else if (pics[lpPicFile].bTerrain == TheaterChar::A) {
+					} else if (pPicData->bTerrain == TheaterChar::A) {
 						buildinginfo[n].bSnow = TRUE;
-					} else if (pics[lpPicFile].bTerrain == TheaterChar::U) {
+					} else if (pPicData->bTerrain == TheaterChar::U) {
 						buildinginfo[n].bUrban = TRUE;
 					}
 				} else {
@@ -3731,8 +3696,8 @@ void CMapData::UpdateBuildingInfo(const CString* lpUnitType)
 				for (auto k = 0; k < 8; k++) {
 					lpPicFile = GetUnitPictureFilename(type, k);
 
-					if (pics.find(lpPicFile) != pics.end()) {
-						buildinginfo[n].pic[k] = pics[lpPicFile];
+					if (auto const pPicData = images.Read(lpPicFile)) {
+						buildinginfo[n].pic[k] = *pPicData; // seems kinda dangerous
 					} else {
 						buildinginfo[n].pic[k].pic = NULL;
 					}
@@ -3768,8 +3733,8 @@ void CMapData::UpdateBuildingInfo(const CString* lpUnitType)
 				for (k = 0; k < 8; k++) {
 					lpPicFile = GetUnitPictureFilename(type, k);
 
-					if (pics.find(lpPicFile) != pics.end()) {
-						buildinginfo[n].pic[k] = pics[lpPicFile];
+					if (auto const pPicData = images.Read(lpPicFile)) {
+						buildinginfo[n].pic[k] = *pPicData; // seems kinda dangerous
 					} else {
 						buildinginfo[n].pic[k].pic = NULL;
 					}
@@ -3800,8 +3765,8 @@ void CMapData::UpdateBuildingInfo(const CString* lpUnitType)
 		for (k = 0; k < 8; k++) {
 			lpPicFile = GetUnitPictureFilename(type, k);
 
-			if (pics.find(lpPicFile) != pics.end()) {
-				buildinginfo[n].pic[k] = pics[lpPicFile];
+			if (auto const pPicData = images.Read(lpPicFile)) {
+				buildinginfo[n].pic[k] = *pPicData; // seems kinda dangerous
 			} else {
 				buildinginfo[n].pic[k].pic = NULL;
 			}
@@ -3812,6 +3777,7 @@ void CMapData::UpdateBuildingInfo(const CString* lpUnitType)
 void CMapData::UpdateTreeInfo(const CString* lpTreeType)
 {
 	CIniFile& ini = GetIniFile();
+	auto const& images = GlobalObjectPool::Instance().Images();
 
 	if (!lpTreeType) {
 		memset(treeinfo, 0, 0x0F00 * sizeof(TREE_INFO));
@@ -3832,9 +3798,8 @@ void CMapData::UpdateTreeInfo(const CString* lpTreeType)
 
 				CString lpPicFile = GetUnitPictureFilename(type, 0);
 
-				if (pics.find(lpPicFile) != pics.end()) {
-
-					treeinfo[n].pic = pics[lpPicFile];
+				if (auto const pPicData = images.Read(lpPicFile)) {
+					treeinfo[n].pic = *pPicData; // seems kinda dangerous
 				} else
 					treeinfo[n].pic.pic = NULL;
 			}
@@ -3855,8 +3820,8 @@ void CMapData::UpdateTreeInfo(const CString* lpTreeType)
 
 				CString lpPicFile = GetUnitPictureFilename(type, 0);
 
-				if (pics.find(lpPicFile) != pics.end()) {
-					treeinfo[n].pic = pics[lpPicFile];
+				if (auto const pPicData = images.Read(lpPicFile)) {
+					treeinfo[n].pic = *pPicData; // seems kinda dangerous
 				} else
 					treeinfo[n].pic.pic = NULL;
 			}
@@ -3878,8 +3843,8 @@ void CMapData::UpdateTreeInfo(const CString* lpTreeType)
 		treeinfo[n].h = foundation.Height;
 
 		CString lpPicFile = GetUnitPictureFilename(type, 0);
-		if (pics.find(lpPicFile) != pics.end()) {
-			treeinfo[n].pic = pics[lpPicFile];
+		if (auto const pPicData = images.Read(lpPicFile)) {
+			treeinfo[n].pic = *pPicData; // seems kinda dangerous
 		} else {
 			treeinfo[n].pic.pic = NULL;
 		}
@@ -3983,41 +3948,7 @@ void CMapData::CreateMap(DWORD dwWidth, DWORD dwHeight, LPCTSTR lpTerrainType, D
 	m_mapfile.SetString("Map", "Theater", lpTerrainType);
 	m_mapfile.SetString("Map", "LocalSize", mapsize);
 
-	map<CString, PICDATA>::iterator it = pics.begin();
-	for (int e = 0; e < pics.size(); e++) {
-		try {
-#ifdef NOSURFACES_OBJECTS			
-			if (it->second.bType == PICDATA_TYPE_BMP) {
-				if (auto pPic = std::exchange(it->second.pic, nullptr)) {
-					((LPDIRECTDRAWSURFACE4)pPic)->Release();
-				}
-			} else {
-				if (auto pPic = std::exchange(it->second.pic, nullptr)) {
-					delete[](pPic);
-				}
-				if (auto pBorder = std::exchange(it->second.vborder, nullptr)) {
-					delete[](pBorder);
-				}
-			}
-#else
-			if (it->second.pic != NULL) it->second.pic->Release();
-#endif
-
-			it->second.pic = NULL;
-		} catch (...) {
-			CString err;
-			err = "Access violation while trying to release surface ";
-			char c[6];
-			itoa(e, c, 10);
-			err += c;
-
-			err += "\n";
-			OutputDebugString(err);
-			continue;
-		}
-
-		it++;
-	}
+	GlobalObjectPool::Instance().Images().ResetAll();
 
 	std::unique_ptr<CDynamicGraphDlg> dlg;
 	if (theApp.m_pMainWnd) {
@@ -4026,7 +3957,6 @@ void CMapData::CreateMap(DWORD dwWidth, DWORD dwHeight, LPCTSTR lpTerrainType, D
 		dlg->UpdateWindow();
 	}
 
-	pics.clear();
 	missingimages.clear();
 
 	UpdateBuildingInfo();
@@ -6682,6 +6612,7 @@ void CMapData::UpdateSmudges(BOOL bSave, int num)
 void CMapData::UpdateSmudgeInfo(LPCSTR lpSmudgeType)
 {
 	CIniFile& ini = GetIniFile();
+	auto const& images = GlobalObjectPool::Instance().Images();
 
 	if (!lpSmudgeType) {
 		memset(smudgeinfo, 0, 0x0F00 * sizeof(SMUDGE_INFO));
@@ -6693,8 +6624,8 @@ void CMapData::UpdateSmudgeInfo(LPCSTR lpSmudgeType)
 			if (n >= 0 && n < 0x0F00) {
 				CString lpPicFile = GetUnitPictureFilename(type, 0);
 
-				if (pics.find(lpPicFile) != pics.end()) {
-					smudgeinfo[n].pic = pics[lpPicFile];
+				if (auto const pPicData = images.Read(lpPicFile)) {
+					smudgeinfo[n].pic = *pPicData; // seems kinda dangerous
 				} else {
 					smudgeinfo[n].pic.pic = NULL;
 				}
@@ -6711,8 +6642,8 @@ void CMapData::UpdateSmudgeInfo(LPCSTR lpSmudgeType)
 
 				CString lpPicFile = GetUnitPictureFilename(type, 0);
 
-				if (pics.find(lpPicFile) != pics.end()) {
-					smudgeinfo[n].pic = pics[lpPicFile];
+				if (auto const pPicData = images.Read(lpPicFile)) {
+					smudgeinfo[n].pic = *pPicData; // seems kinda dangerous
 				} else {
 					smudgeinfo[n].pic.pic = NULL;
 				}
@@ -6729,9 +6660,8 @@ void CMapData::UpdateSmudgeInfo(LPCSTR lpSmudgeType)
 
 	if (n >= 0 && n < 0x0F00) {
 		CString lpPicFile = GetUnitPictureFilename(type, 0);
-		if (pics.find(lpPicFile) != pics.end()) {
-
-			smudgeinfo[n].pic = pics[lpPicFile];
+		if (auto const pPicData = images.Read(lpPicFile)) {
+			smudgeinfo[n].pic = *pPicData; // seems kinda dangerous
 		} else {
 			smudgeinfo[n].pic.pic = NULL;
 		}

--- a/MissionEditor/Structs.h
+++ b/MissionEditor/Structs.h
@@ -263,7 +263,7 @@ building infos
 */
 struct BUILDING_INFO
 {
-	PICDATA pic[8];
+	PICDATA pic[8]; // pic data are read only reference
 	int pic_count;
 	BYTE w;
 	BYTE h;

--- a/MissionEditor/inlines.h
+++ b/MissionEditor/inlines.h
@@ -26,6 +26,7 @@
 #include "mapdata.h"
 #include "variables.h"
 #include "ovrlinline.h"
+#include "GlobalObjectPool.h"
 #include <string>
 #include <vector>
 #include <ranges>
@@ -59,8 +60,10 @@ inline CString GetUnitPictureFilename(const CString& artSectionId, DWORD dwPicIn
 
 	// store differently for each type even they shares same image,
 	// because they can have different components, e.g. turret image
-	if (pics.find(artSectionId + n) != pics.end()) {
-		return artSectionId + n;
+	auto& images = GlobalObjectPool::Instance().Images();
+	auto existingId = artSectionId + n;
+	if (images.Read(existingId)) {
+		return existingId;
 	}
 	auto artname = artSectionId;
 	auto const& shapeName = art.GetString(artSectionId, "Image");
@@ -76,13 +79,13 @@ inline CString GetUnitPictureFilename(const CString& artSectionId, DWORD dwPicIn
 	if (art.GetBool(artname, "NewTheater") && !art.GetBool(artname, "DemandLoad")) {
 		filename.SetAt(1, 'T');
 	}
-
-	if (pics.find(artname + n) != pics.end()) {
-		return artname + n;
+	existingId = artname + n;
+	if (images.Read(existingId)) {
+		return existingId;
 	}
-
-	if (pics.find(artname + ".bmp") != pics.end()) { // since June, 15th (Matze): Only use BMP if no SHP/VXL exists
-		return artname + ".bmp";
+	existingId = artname + ".bmp";
+	if (images.Read(existingId)) { // since June, 15th (Matze): Only use BMP if no SHP/VXL exists
+		return existingId;
 	}
 
 	return {};

--- a/MissionEditor/variables.h
+++ b/MissionEditor/variables.h
@@ -59,8 +59,6 @@ extern BOOL bOptionsStartup;
 // the current file beeing edited.
 extern CString currentMapFile;
 
-// all the pictures shown in the mapview
-extern map<CString, PICDATA> pics;
 extern TILEDATA* t_tiledata;
 extern TILEDATA* s_tiledata;
 extern TILEDATA* u_tiledata;

--- a/MissionEditorPackLib/MissionEditorPackLib.cpp
+++ b/MissionEditorPackLib/MissionEditorPackLib.cpp
@@ -55,6 +55,7 @@ struct IUnknown;
 #include <regex>
 
 #include "VoxelNormals.h"
+#include <assert.h>
 
 size_t constexpr mixfileCachedCapacity = 2000;
 Cmix_file mixfiles[mixfileCachedCapacity];
@@ -958,9 +959,6 @@ namespace FSunPackLib
 		t_shp_ts_image_header imghead;
 		BYTE* image = NULL;
 
-
-
-
 		auto& head = cur_shp.header();
 		if (head.cx == 0 || head.cy == 0) {
 			return FALSE;
@@ -971,6 +969,7 @@ namespace FSunPackLib
 
 		std::vector<byte> decode_image_buffer;
 		for (auto frameIdx = 0; frameIdx < wantedNum; frameIdx++) {
+			assert(lpPics[frameIdx] == 0);
 			if (cur_shp.get_image_header(startIndex + frameIdx)) {
 				imghead = *(cur_shp.get_image_header(startIndex + frameIdx));
 				// if(imghead.offset!=0)
@@ -982,7 +981,6 @@ namespace FSunPackLib
 						decode3(cur_shp.get_image(startIndex + frameIdx), image, imghead.cx, imghead.cy);
 					} else
 						image = (unsigned char*)cur_shp.get_image(startIndex + frameIdx);
-
 
 					lpPics[frameIdx] = new(BYTE[head.cx * head.cy]);
 


### PR DESCRIPTION
此问题发生在编辑器关闭时，会影响工作区切换的重新启动程序，也有潜在的其它崩溃风险。
### 复现方法：
* 裤头任务包第三关特殊步兵单位 GASTOW2 在art中赋予了Image=INVISO，步兵序列读取时无法读满8帧
### 根本原因
pic指针返回值未置空，栈内存脏数据被写入单位的图像pic指针处。理论上在特定情况绘图也会导致运行时崩溃。
