### PR TITLE
fix: missing trigger option value update when persistence changed .

### DIFF
--- a/MissionEditor/TriggerDef.cpp
+++ b/MissionEditor/TriggerDef.cpp
@@ -213,7 +213,7 @@ TriggerOptions::TriggerOptions(const CString& fullData)
         return;
     }
 
-    auto const params = SplitParams<7>(fullData);
+    auto const params = SplitParams<8>(fullData);
 
     house = params[0];
     nextTrigger = params[1];
@@ -222,6 +222,7 @@ TriggerOptions::TriggerOptions(const CString& fullData)
     controls[Easy] = static_cast<bool>(atoi(params[4]));
     controls[Medium] = static_cast<bool>(atoi(params[5]));
     controls[Hard] = static_cast<bool>(atoi(params[6]));
+    controls[MustTransfer] = static_cast<bool>(atoi(params[7]));
 }
 
 CString TriggerOptions::Serialize() const
@@ -235,7 +236,7 @@ CString TriggerOptions::Serialize() const
         static_cast<int>(controls[Easy]),
         static_cast<int>(controls[Medium]),
         static_cast<int>(controls[Hard]),
-        static_cast<int>(controls[__unused])
+        static_cast<int>(controls[MustTransfer])
     );
     return ret;
 }

--- a/MissionEditor/TriggerDef.h
+++ b/MissionEditor/TriggerDef.h
@@ -58,7 +58,7 @@ struct TriggerOptions
         Easy,
         Medium,
         Hard,
-        __unused,
+        MustTransfer,
         __ControlCount,
     };
 

--- a/MissionEditor/TriggerEditorAllDlg.cpp
+++ b/MissionEditor/TriggerEditorAllDlg.cpp
@@ -576,7 +576,7 @@ void CTriggerEditorAllDlg::onChangePersistence()
     }
 
     auto& opt = TriggerDatabase::Instance().Lookup(m_currentTrigger).Options();
-    opt.controls[TriggerOptions::MustTransfer] = persistenceVal > 0;
+    opt.controls[TriggerOptions::MustTransfer] = hasTagLinked && persistenceVal > 0;
 }
 
 void CTriggerEditorAllDlg::onEditChangeHouse()

--- a/MissionEditor/TriggerEditorAllDlg.cpp
+++ b/MissionEditor/TriggerEditorAllDlg.cpp
@@ -563,15 +563,20 @@ void CTriggerEditorAllDlg::onChangePersistence()
     m_persistence.GetWindowText(persistenceStr);
     persistenceStr.Trim();
 
+    bool hasTagLinked = false;
+    auto const persistenceVal = atoi(persistenceStr);
     auto& tagDb = TagDatabase::Instance();
     // locate that tag and update its value
     for (auto& tag : tagDb) {
         if (tag.triggerId == m_currentTrigger) {
-            tag.persistence = atoi(persistenceStr);
+            tag.persistence = persistenceVal;
+            hasTagLinked = true;
             break;
         }
     }
 
+    auto& opt = TriggerDatabase::Instance().Lookup(m_currentTrigger).Options();
+    opt.controls[TriggerOptions::MustTransfer] = persistenceVal > 0;
 }
 
 void CTriggerEditorAllDlg::onEditChangeHouse()

--- a/MissionEditor/TriggerEditorAllDlg.cpp
+++ b/MissionEditor/TriggerEditorAllDlg.cpp
@@ -13,6 +13,7 @@ BEGIN_MESSAGE_MAP(CTriggerEditorAllDlg, CDialog)
     ON_BN_CLICKED(IDC_TRGR_DELETE_TRIGGER, onDeleteTrigger)
     ON_BN_CLICKED(IDC_TRGR_CLONE_TRIGGER, onCloneTrigger)
     ON_BN_CLICKED(IDC_TRGR_PLACE_ON_MAP, onPlaceOnMap)
+    ON_BN_CLICKED(IDC_TRGR_MUST_TRANSFER, OnBnClickedTrgrMustTransfer)
     ON_BN_CLICKED(IDC_TRGR_DISABLED, OnDisabled)
     ON_BN_CLICKED(IDC_TRGR_EASY, OnEasy)
     ON_BN_CLICKED(IDC_TRGR_MEDIUM, OnMedium)
@@ -139,6 +140,7 @@ void CTriggerEditorAllDlg::translateUI()
     TranslateDlgItem(*this, IDC_TRGR_EASY, "TriggerOptionEasy");
     TranslateDlgItem(*this, IDC_TRGR_MEDIUM, "TriggerOptionMedium");
     TranslateDlgItem(*this, IDC_TRGR_HARD, "TriggerOptionHard");
+    TranslateDlgItem(*this, IDC_TRGR_MUST_TRANSFER, "TriggerOptionMustTransfer");
     TranslateDlgItem(*this, IDC_TRGR_EVENT_OPTIONS, "TriggerEventOptions");
     TranslateDlgItem(*this, IDC_TRGR_EVENT_TYPE_TXT, "TriggerEventType");
     TranslateDlgItem(*this, IDC_TRGR_NEW_EVENT, "TriggerNew");
@@ -563,20 +565,15 @@ void CTriggerEditorAllDlg::onChangePersistence()
     m_persistence.GetWindowText(persistenceStr);
     persistenceStr.Trim();
 
-    bool hasTagLinked = false;
-    auto const persistenceVal = atoi(persistenceStr);
     auto& tagDb = TagDatabase::Instance();
     // locate that tag and update its value
     for (auto& tag : tagDb) {
         if (tag.triggerId == m_currentTrigger) {
-            tag.persistence = persistenceVal;
-            hasTagLinked = true;
+            tag.persistence = atoi(persistenceStr);
             break;
         }
     }
 
-    auto& opt = TriggerDatabase::Instance().Lookup(m_currentTrigger).Options();
-    opt.controls[TriggerOptions::MustTransfer] = hasTagLinked && persistenceVal > 0;
 }
 
 void CTriggerEditorAllDlg::onEditChangeHouse()
@@ -667,7 +664,7 @@ void CTriggerEditorAllDlg::onOptionCheckChanged(
     if (m_currentTrigger.IsEmpty()) {
         return;
     }
-    auto const checked = checkBtn.GetCheck() != 0;
+    auto const checked = checkBtn.GetCheck() == BST_CHECKED;
     auto& trigger = TriggerDatabase::Instance().Lookup(m_currentTrigger);
     trigger.Options().controls[control] = checked;
 }
@@ -675,6 +672,13 @@ void CTriggerEditorAllDlg::onOptionCheckChanged(
 void CTriggerEditorAllDlg::ParseTriggerDefinitions()
 {
     TriggerDefinitionManager::Instance().LoadFrom(g_data, errstream);
+}
+
+void CTriggerEditorAllDlg::OnBnClickedTrgrMustTransfer()
+{
+    // not using DDX binding because it causing Chinese character missing
+    auto& btn = *reinterpret_cast<CButton*>(GetDlgItem(IDC_TRGR_MUST_TRANSFER));
+    onOptionCheckChanged(btn, TriggerOptions::MustTransfer);
 }
 
 void CTriggerEditorAllDlg::OnDisabled()
@@ -710,6 +714,7 @@ void CTriggerEditorAllDlg::onSelChangeOption()
     CString attachedTrigger = options.nextTrigger;
     m_nextTrigger.SetWindowText(attachedTrigger);
 
+    reinterpret_cast<CButton*>(GetDlgItem(IDC_TRGR_MUST_TRANSFER))->SetCheck(options.controls[TriggerOptions::MustTransfer]);
     m_disabled.SetCheck(options.controls[TriggerOptions::Disable]);
     m_easy.SetCheck(options.controls[TriggerOptions::Easy]);
     m_medium.SetCheck(options.controls[TriggerOptions::Medium]);

--- a/MissionEditor/TriggerEditorAllDlg.h
+++ b/MissionEditor/TriggerEditorAllDlg.h
@@ -88,6 +88,7 @@ protected:
     CButton	m_hard;
     CButton	m_easy;
     CButton	m_disabled;
+    //CButton	m_mustTransfer;
     // event options
     CMyComboBox m_eventTypes;
     CListBox m_eventList;
@@ -104,4 +105,5 @@ public:
     DECLARE_MESSAGE_MAP()
     afx_msg void onCloneTrigger();
     afx_msg void onEditAttachedTrigger();
+    afx_msg void OnBnClickedTrgrMustTransfer();
 };

--- a/MissionEditor/data/FinalAlert2/FALanguage.ini
+++ b/MissionEditor/data/FinalAlert2/FALanguage.ini
@@ -1552,6 +1552,7 @@ TriggerOptionHouse=参战方:
 TriggerOptionAttachedTrigger=下联触发:
 TriggerOptionDisableTip=被禁止的触发必须由其它触发激活后才能继续运作
 TriggerOptionDisabled=禁止
+TriggerOptionMustTransfer=窃车逻辑标签转移
 TriggerOptionEasy=简单
 TriggerOptionMedium=中等
 TriggerOptionHard=困难

--- a/MissionEditor/res/TriggerEditor.rc
+++ b/MissionEditor/res/TriggerEditor.rc
@@ -81,10 +81,11 @@ BEGIN
     COMBOBOX        IDC_TRGR_TYPE,213,49,90,63,CBS_DROPDOWN | CBS_AUTOHSCROLL | CBS_SORT | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Name",IDC_TRGR_NAME_TXT,13,33,36,10
     EDITTEXT        IDC_TRGR_NAME,69,33,234,12,ES_AUTOHSCROLL
-    LTEXT           "House:",IDC_TRGR_HOUSE_TXT,13,49,38,10
+    LTEXT           "House:",IDC_TRGR_HOUSE_TXT,13,52,38,10
     COMBOBOX        IDC_TRGR_HOUSE,69,49,90,105,CBS_DROPDOWN | CBS_AUTOHSCROLL | CBS_SORT | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Trigger attached:",IDC_TRGR_ATTACHED_TRIGGER_TXT,13,65,58,8
     COMBOBOX        IDC_TRGR_ATTACHED_TRIGGER,69,65,234,127,CBS_DROPDOWN | CBS_AUTOHSCROLL | CBS_SORT | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Must Transfer",IDC_TRGR_MUST_TRANSFER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,308,52,84,10
     CONTROL         "Disabled",IDC_TRGR_DISABLED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,394,49,40,13
     CONTROL         "Easy",IDC_TRGR_EASY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,308,65,35,13
     CONTROL         "Medium",IDC_TRGR_MEDIUM,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,351,65,35,13
@@ -135,6 +136,7 @@ GUIDELINES DESIGNINFO
 BEGIN
     IDD_TRIGGER_ALL, DIALOG
     BEGIN
+        HORZGUIDE, 62
     END
 END
 #endif    // APSTUDIO_INVOKED
@@ -208,70 +210,6 @@ BEGIN
     COMBOBOX        IDC_TRIGGER,61,131,236,135,CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
     LTEXT           "For every trigger you create, you should create a tag to make the trigger work. A trigger consists of some general properties, an event and an action, which can all be defined in the ""trigger"" section.",IDC_TAGS_DESC_2,7,167,290,30
 END
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// DESIGNINFO
-//
-
-#ifdef APSTUDIO_INVOKED
-GUIDELINES DESIGNINFO
-BEGIN
-    IDD_TRIGGERS, DIALOG
-    BEGIN
-    END
-
-    IDD_TRIGGEREDITOR, DIALOG
-    BEGIN
-        RIGHTMARGIN, 384
-        VERTGUIDE, 228
-        BOTTOMMARGIN, 258
-    END
-
-    IDD_TRIGGEROPTIONS, DIALOG
-    BEGIN
-        VERTGUIDE, 4
-        VERTGUIDE, 356
-    END
-
-    IDD_TRIGGEREVENTS, DIALOG
-    BEGIN
-        RIGHTMARGIN, 361
-        VERTGUIDE, 6
-        VERTGUIDE, 14
-        VERTGUIDE, 72
-        VERTGUIDE, 173
-        VERTGUIDE, 185
-        VERTGUIDE, 222
-        VERTGUIDE, 233
-        VERTGUIDE, 294
-        VERTGUIDE, 300
-        VERTGUIDE, 354
-        HORZGUIDE, 6
-        HORZGUIDE, 79
-    END
-
-    IDD_TRIGGERACTIONS, DIALOG
-    BEGIN
-        RIGHTMARGIN, 360
-        VERTGUIDE, 6
-        VERTGUIDE, 14
-        VERTGUIDE, 72
-        VERTGUIDE, 110
-        VERTGUIDE, 174
-        VERTGUIDE, 186
-        VERTGUIDE, 221
-        VERTGUIDE, 233
-        VERTGUIDE, 293
-        VERTGUIDE, 301
-        VERTGUIDE, 354
-        BOTTOMMARGIN, 194
-        HORZGUIDE, 6
-        HORZGUIDE, 74
-        HORZGUIDE, 79
-    END
-END
-#endif    // APSTUDIO_INVOKED
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/MissionEditor/res/resource.h
+++ b/MissionEditor/res/resource.h
@@ -719,6 +719,7 @@
 #define IDC_TERRAIN_MGR_REMOVE          1578
 #define IDC_TERRAIN_MGR_REMOVE2         1579
 #define IDC_TERRAIN_MGR_ADD             1579
+#define IDC_TRGR_MUST_TRANSFER          1579
 #define IDC_TRGR_TRIGGER_OPTIONS        1601
 #define IDC_TRGR_SELECT_TRIGGER_TXT     1602
 #define IDC_TRGR_SELECTED_TRIGGER       1603
@@ -869,7 +870,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        333
 #define _APS_NEXT_COMMAND_VALUE         40144
-#define _APS_NEXT_CONTROL_VALUE         1579
+#define _APS_NEXT_CONTROL_VALUE         1580
 #define _APS_NEXT_SYMED_VALUE           111
 #endif
 #endif


### PR DESCRIPTION
跟旧版编辑器对比，对一个触发修改其生命周期，触发选项的最后一个值的变化情况。
~理论上，当persitence不为0时，该值为1，否则为0。~ 这个在YRPP里定义叫MustTransfer
现在改为独立控制的开关。

<img width="837" height="777" alt="image" src="https://github.com/user-attachments/assets/9572a93d-1ecf-4c55-9554-c28e6296b4c3" />
