### PR TITLE
Release workflow commit hash fix .

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,5 +113,5 @@ jobs:
         tag_name: ${{ env.RELEASE_VER }}
         name: ${{ env.RELEASE_VER }}
         files: dist/${{ env.PACKAGE_NAME }}
-        target_commitish: ${{ github.ref }}
+        target_commitish: ${{ github.sha }}
         prerelease: ${{ env.IS_PRERELEASE }}


### PR DESCRIPTION
using github.sha instead of github.ref to avoid multiple release point to the same latest main .